### PR TITLE
fix: add devServer exclude to allow frontend rendering

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    devServer({ entry: 'src/server/index.ts' }),
+    devServer({
+      entry: 'src/server/index.ts',
+      exclude: [/^\/(?!api\/).*/],
+    }),
   ],
 })


### PR DESCRIPTION
## Summary
- `@hono/vite-dev-server` がすべてのリクエストを Hono にルーティングしており、`/` アクセス時に 404 が発生していた
- `devServer` に `exclude: [/^\/(?!api\/).*/]` を追加し、`/api/*` 以外のリクエストを Vite（SPA）側にフォールバックさせる

## Test plan
- [x] 全104ユニットテストがパス
- [x] ESLint エラーなし
- [x] TypeScript 型チェック エラーなし
- [ ] `npm run dev` で `http://localhost:5173/` にアクセスしてフロントエンドが表示されることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)