### PR TITLE
fix: address PR review findings for image generation

### DIFF
--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '../test/test-utils'
 import Top3Image from './Top3Image'
 import type { SearchResultItem } from '../types/common'
@@ -44,6 +44,10 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
 function mockCreateElementForAnchor() {
   const clickSpy = vi.fn()
   let capturedDownload = ''
@@ -53,8 +57,6 @@ function mockCreateElementForAnchor() {
     if (tag === 'a') {
       return {
         click: clickSpy,
-        _download: '',
-        _href: '',
         set download(v: string) {
           capturedDownload = v
         },
@@ -208,8 +210,6 @@ describe('Top3Image', () => {
       })
 
       expect(clickSpy).toHaveBeenCalledTimes(1)
-
-      vi.restoreAllMocks()
     })
 
     it('uses theme in download filename when provided', async () => {
@@ -234,8 +234,6 @@ describe('Top3Image', () => {
       await waitFor(() => {
         expect(getDownload()).toBe('my-top3-テストテーマ.png')
       })
-
-      vi.restoreAllMocks()
     })
 
     it('sanitizes special characters in theme for filename', async () => {
@@ -260,8 +258,6 @@ describe('Top3Image', () => {
       await waitFor(() => {
         expect(getDownload()).toBe('my-top3-test_path_name__bad.png')
       })
-
-      vi.restoreAllMocks()
     })
 
     it('shows loading state and disables button during generation', async () => {
@@ -348,8 +344,6 @@ describe('Top3Image', () => {
           ),
         ).toBeInTheDocument()
       })
-
-      vi.restoreAllMocks()
     })
 
     it('shows CORS-specific error for SecurityError', async () => {
@@ -376,8 +370,6 @@ describe('Top3Image', () => {
           ),
         ).toBeInTheDocument()
       })
-
-      vi.restoreAllMocks()
     })
 
     it('resets generating state after error', async () => {
@@ -400,8 +392,6 @@ describe('Top3Image', () => {
         expect(screen.getByText('画像をダウンロード')).toBeInTheDocument()
       })
       expect(screen.getByRole('button')).toBeEnabled()
-
-      vi.restoreAllMocks()
     })
 
     it('clears previous error on new download attempt', async () => {
@@ -442,8 +432,6 @@ describe('Top3Image', () => {
           ),
         ).not.toBeInTheDocument()
       })
-
-      vi.restoreAllMocks()
     })
   })
 })

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -103,8 +103,9 @@ function ImageWorkCard({ item, label }: ImageWorkCardProps) {
         crossOrigin="anonymous"
         onError={(e) => {
           const img = e.target as HTMLImageElement
-          img.crossOrigin = null as unknown as string
-          img.src = NO_IMAGE_SRC
+          if (img.src !== NO_IMAGE_SRC) {
+            img.src = NO_IMAGE_SRC
+          }
         }}
         style={{
           width: 200,
@@ -138,7 +139,21 @@ function ImageWorkCard({ item, label }: ImageWorkCardProps) {
 }
 
 function sanitizeFilename(name: string): string {
-  return name.replace(/[/\\:*?"<>|]/g, '_').slice(0, 50)
+  return name
+    .replace(/[/\\:*?"<>|\0\n\r]/g, '_')
+    .replace(/^\.+/, '')
+    .trim()
+    .slice(0, 50)
+}
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof DOMException && err.name === 'SecurityError') {
+    return '画像の取得に失敗しました。外部画像のCORS設定が原因の可能性があります。'
+  }
+  if (err instanceof DOMException && err.name === 'QuotaExceededError') {
+    return '画像サイズが大きすぎるため生成できませんでした。'
+  }
+  return '画像の生成に失敗しました。もう一度お試しください。'
 }
 
 function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
@@ -173,12 +188,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
       link.href = dataUrl
       link.click()
     } catch (err) {
-      const message =
-        err instanceof DOMException && err.name === 'SecurityError'
-          ? '画像の取得に失敗しました。外部画像のCORS設定が原因の可能性があります。'
-          : '画像の生成に失敗しました。もう一度お試しください。'
       console.error('[Top3Image] Failed to generate image:', err)
-      setError(message)
+      setError(getErrorMessage(err))
     } finally {
       setIsGenerating(false)
     }

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import { parseTop3Params } from '../utils/url-params'
 import Top3Image from '../components/Top3Image'
-import type { SearchResultItem } from '../types/common'
+import type { MediaCategory, SearchResultItem } from '../types/common'
 
 type WorkState = {
   data: SearchResultItem | null
@@ -13,11 +13,17 @@ type WorkState = {
   error: string | null
 }
 
+const CATEGORY_LABELS: Record<MediaCategory, string> = {
+  book: '書籍',
+  music: '音楽',
+  movie: '映画',
+}
+
 async function fetchWork(
-  category: 'book' | 'music' | 'movie',
+  category: MediaCategory,
   id: string,
 ): Promise<SearchResultItem> {
-  const endpoints: Record<string, string> = {
+  const endpoints: Record<MediaCategory, string> = {
     book: `/api/books/${id}`,
     music: `/api/music/${id}`,
     movie: `/api/movies/${id}`,
@@ -38,10 +44,7 @@ async function fetchWork(
   return result.data
 }
 
-function useWorkFetch(
-  category: 'book' | 'music' | 'movie',
-  id: string,
-): WorkState {
+function useWorkFetch(category: MediaCategory, id: string): WorkState {
   const [state, setState] = useState<WorkState>(() => ({
     data: null,
     loading: !!id,
@@ -56,12 +59,17 @@ function useWorkFetch(
         if (!cancelled) setState({ data, loading: false, error: null })
       })
       .catch((err) => {
-        if (!cancelled)
+        if (!cancelled) {
+          console.error(
+            `[Top3Page] Failed to fetch ${category} (id: ${id}):`,
+            err,
+          )
           setState({
             data: null,
             loading: false,
-            error: (err as Error).message,
+            error: `${CATEGORY_LABELS[category]}の取得に失敗しました`,
           })
+        }
       })
     return () => {
       cancelled = true
@@ -71,17 +79,14 @@ function useWorkFetch(
   return state
 }
 
-function WorkCard({
-  work,
-  loading,
-  error,
-  label,
-}: {
+type WorkCardProps = {
   work: SearchResultItem | null
   loading: boolean
   error: string | null
   label: string
-}) {
+}
+
+function WorkCard({ work, loading, error, label }: WorkCardProps) {
   if (loading) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-gray-200 bg-white p-4">
@@ -175,6 +180,10 @@ function Top3Page() {
   const movie = useWorkFetch('movie', params.movieId)
 
   const hasAnyId = params.bookId || params.musicId || params.movieId
+  const allLoaded = !book.loading && !music.loading && !movie.loading
+  const noErrors = !book.error && !music.error && !movie.error
+  const hasAnyData = !!(book.data || music.data || movie.data)
+  const showImage = allLoaded && noErrors && hasAnyData
 
   if (!hasAnyId) {
     return (
@@ -229,22 +238,16 @@ function Top3Page() {
         </div>
 
         {/* Image Generation -- only show when all data is loaded */}
-        {!book.loading &&
-          !music.loading &&
-          !movie.loading &&
-          !book.error &&
-          !music.error &&
-          !movie.error &&
-          (book.data || music.data || movie.data) && (
-            <div className="mt-8">
-              <Top3Image
-                theme={params.theme}
-                book={book.data}
-                music={music.data}
-                movie={movie.data}
-              />
-            </div>
-          )}
+        {showImage && (
+          <div className="mt-8">
+            <Top3Image
+              theme={params.theme}
+              book={book.data}
+              music={music.data}
+              movie={movie.data}
+            />
+          </div>
+        )}
 
         <div className="mt-6 text-center">
           <Button component={Link} to="/" variant="outlined">

--- a/src/utils/url-params.ts
+++ b/src/utils/url-params.ts
@@ -36,9 +36,12 @@ export function buildTop3Url(selection: Selection, theme: string): string {
   return queryString ? `/my-top3?${queryString}` : '/my-top3'
 }
 
+const MAX_THEME_URL_LENGTH = 100
+
 export function parseTop3Params(searchParams: URLSearchParams): Top3Params {
+  const rawTheme = searchParams.get('theme') ?? ''
   return {
-    theme: searchParams.get('theme') ?? '',
+    theme: rawTheme.slice(0, MAX_THEME_URL_LENGTH),
     bookId: searchParams.get('book') ?? '',
     musicId: searchParams.get('music') ?? '',
     movieId: searchParams.get('movie') ?? '',


### PR DESCRIPTION
- Fix onError infinite loop risk with guard condition, remove dead crossOrigin hack
- Extract getErrorMessage with QuotaExceededError support
- Harden sanitizeFilename (null bytes, newlines, leading dots)
- Use MediaCategory type consistently in Top3Page
- Add console.error logging and user-friendly Japanese error messages in useWorkFetch
- Extract readability variables for image generation visibility condition
- Limit theme length from URL params to 100 chars
- Add afterEach(vi.restoreAllMocks) for reliable test cleanup