### PR TITLE
fix: allow myno1s.exe.xyz host in Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig(({ mode }) => {
   Object.assign(process.env, env)
 
   return {
+    server: {
+      allowedHosts: ['myno1s.exe.xyz'],
+    },
     plugins: [
       react(),
       tailwindcss(),


### PR DESCRIPTION
Vite dev serverの`server.allowedHosts`に`myno1s.exe.xyz`を追加し、exe.devプロキシ経由のアクセスを許可する。