### PR TITLE
feat: テーマ履歴機能の実装 (#16)

### DIFF
--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -10,6 +10,7 @@ import type { MediaCategory, SearchResultItem } from '../types/common'
 
 type SelectionAreaProps = {
   theme: string
+  onBeforeCreate?: () => void
 }
 
 const CATEGORY_LABELS: Record<MediaCategory, string> = {
@@ -104,11 +105,12 @@ function SlotCard({
   )
 }
 
-function SelectionArea({ theme }: SelectionAreaProps) {
+function SelectionArea({ theme, onBeforeCreate }: SelectionAreaProps) {
   const { selection, deselectItem, isComplete } = useSelection()
   const navigate = useNavigate()
 
   const handleCreate = () => {
+    onBeforeCreate?.()
     const url = buildTop3Url(selection, theme)
     navigate(url)
   }

--- a/src/components/ThemeHistory.tsx
+++ b/src/components/ThemeHistory.tsx
@@ -1,0 +1,55 @@
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Typography from '@mui/material/Typography'
+import { useThemeHistory } from '../hooks/useThemeHistory'
+
+type ThemeHistoryProps = {
+  onSelect: (theme: string) => void
+}
+
+export default function ThemeHistory({ onSelect }: ThemeHistoryProps) {
+  const { history, removeHistory, clearHistory } = useThemeHistory()
+
+  if (history.length === 0) {
+    return null
+  }
+
+  return (
+    <Box
+      className="mt-2 rounded-lg p-3"
+      sx={{ backgroundColor: 'var(--color-surface)' }}
+      aria-label="テーマ履歴"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <Typography
+          variant="subtitle2"
+          sx={{ color: 'var(--color-text-primary)' }}
+        >
+          最近のテーマ
+        </Typography>
+        <Button
+          variant="text"
+          size="small"
+          onClick={clearHistory}
+          color="primary"
+        >
+          すべて削除
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {history.map((theme) => (
+          <Chip
+            key={theme}
+            label={theme}
+            variant="outlined"
+            size="small"
+            clickable
+            onClick={() => onSelect(theme)}
+            onDelete={() => removeHistory(theme)}
+          />
+        ))}
+      </div>
+    </Box>
+  )
+}

--- a/src/hooks/useThemeHistory.ts
+++ b/src/hooks/useThemeHistory.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback } from 'react'
+
+const MAX_HISTORY_ITEMS = 10
+const STORAGE_KEY = 'theme-history'
+
+type ThemeHistoryItem = {
+  theme: string
+  timestamp: number
+}
+
+type UseThemeHistoryReturn = {
+  history: string[]
+  addHistory: (theme: string) => void
+  removeHistory: (theme: string) => void
+  clearHistory: () => void
+}
+
+function isHistoryItem(item: unknown): item is ThemeHistoryItem {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as ThemeHistoryItem).theme === 'string' &&
+    typeof (item as ThemeHistoryItem).timestamp === 'number'
+  )
+}
+
+function loadHistory(): ThemeHistoryItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      console.warn(
+        `[useThemeHistory] Invalid data format for "${STORAGE_KEY}". Resetting.`,
+      )
+      localStorage.removeItem(STORAGE_KEY)
+      return []
+    }
+    return parsed.filter(isHistoryItem)
+  } catch (error) {
+    console.warn('[useThemeHistory] Failed to load history:', error)
+    return []
+  }
+}
+
+function saveHistory(items: ThemeHistoryItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+  } catch (error) {
+    console.warn('[useThemeHistory] Failed to save history:', error)
+  }
+}
+
+function toThemes(items: ThemeHistoryItem[]): string[] {
+  return [...items]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .map((item) => item.theme)
+}
+
+export function useThemeHistory(): UseThemeHistoryReturn {
+  const [history, setHistory] = useState<string[]>(() =>
+    toThemes(loadHistory()),
+  )
+
+  const addHistory = useCallback((theme: string) => {
+    const trimmed = theme.trim()
+    if (!trimmed) return
+
+    const items = loadHistory()
+    const filtered = items.filter((item) => item.theme !== trimmed)
+    const newItems = [
+      { theme: trimmed, timestamp: Date.now() },
+      ...filtered,
+    ].slice(0, MAX_HISTORY_ITEMS)
+
+    saveHistory(newItems)
+    setHistory(toThemes(newItems))
+  }, [])
+
+  const removeHistory = useCallback((theme: string) => {
+    const items = loadHistory()
+    const filtered = items.filter((item) => item.theme !== theme)
+    saveHistory(filtered)
+    setHistory(toThemes(filtered))
+  }, [])
+
+  const clearHistory = useCallback(() => {
+    saveHistory([])
+    setHistory([])
+  }, [])
+
+  return { history, addHistory, removeHistory, clearHistory }
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -3,12 +3,14 @@ import type { MediaCategory, SearchResultItem } from '../types/common'
 import { useDebounce } from '../hooks/useDebounce'
 import { useSearch } from '../hooks/useSearch'
 import { useSearchHistory } from '../hooks/useSearchHistory'
+import { useThemeHistory } from '../hooks/useThemeHistory'
 import { useSelection } from '../hooks/useSelection'
 import TabSwitcher from '../components/TabSwitcher'
 import SearchBar from '../components/SearchBar'
 import SearchHistory from '../components/SearchHistory'
 import SearchResults from '../components/SearchResults'
 import ThemeInput from '../components/ThemeInput'
+import ThemeHistory from '../components/ThemeHistory'
 import SelectionArea from '../components/SelectionArea'
 
 type QueryState = Record<MediaCategory, string>
@@ -24,6 +26,7 @@ function SearchPage() {
   const [queries, setQueries] = useState<QueryState>(INITIAL_QUERIES)
   const [theme, setTheme] = useState('')
   const { selectItem } = useSelection()
+  const { addHistory: addThemeHistory } = useThemeHistory()
 
   const currentQuery = queries[activeTab]
   const debouncedQuery = useDebounce(currentQuery, 300)
@@ -67,6 +70,14 @@ function SearchPage() {
     [selectItem],
   )
 
+  const handleThemeHistorySelect = useCallback((selectedTheme: string) => {
+    setTheme(selectedTheme)
+  }, [])
+
+  const handleBeforeCreate = useCallback(() => {
+    addThemeHistory(theme)
+  }, [theme, addThemeHistory])
+
   return (
     <div
       className="min-h-screen"
@@ -94,11 +105,12 @@ function SearchPage() {
         {/* Theme Input Area */}
         <div className="mt-6">
           <ThemeInput value={theme} onChange={setTheme} />
+          <ThemeHistory onSelect={handleThemeHistorySelect} />
         </div>
 
         {/* Selection Area */}
         <div className="mt-4">
-          <SelectionArea theme={theme} />
+          <SelectionArea theme={theme} onBeforeCreate={handleBeforeCreate} />
         </div>
 
         {/* Tab Switcher */}


### PR DESCRIPTION
Closes #16

## 変更内容
- テーマ履歴のlocalStorage保存ロジック（`useThemeHistory`フック）
- 履歴からの選択UI（Chip形式、`ThemeHistory`コンポーネント）
- 履歴の個別削除・一括削除機能
- 最大10件まで保存（新しい順に表示）
- Top3作成時にテーマを自動保存
