### PR TITLE
feat: 画像保存機能の改善 (#17)

### DIFF
--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -272,7 +272,9 @@ describe('Top3Image', () => {
       })
 
       await waitFor(() => {
-        expect(getDownload()).toBe(`my-top3-${getTodayDate()}-test_path_name__bad.png`)
+        expect(getDownload()).toBe(
+          `my-top3-${getTodayDate()}-test_path_name__bad.png`,
+        )
       })
     })
 
@@ -308,7 +310,9 @@ describe('Top3Image', () => {
       await waitFor(() => {
         expect(screen.getByText('画像をダウンロード')).toBeInTheDocument()
       })
-      expect(screen.getByRole('button', { name: /画像をダウンロード/ })).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: /画像をダウンロード/ }),
+      ).toBeEnabled()
     })
 
     it('shows error when toDataURL returns empty', async () => {
@@ -407,7 +411,9 @@ describe('Top3Image', () => {
       await waitFor(() => {
         expect(screen.getByText('画像をダウンロード')).toBeInTheDocument()
       })
-      expect(screen.getByRole('button', { name: /画像をダウンロード/ })).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: /画像をダウンロード/ }),
+      ).toBeEnabled()
     })
 
     it('clears previous error on new download attempt', async () => {

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -341,11 +341,7 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
         onClose={() => setError(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
-        <Alert
-          onClose={() => setError(null)}
-          severity="error"
-          variant="filled"
-        >
+        <Alert onClose={() => setError(null)} severity="error" variant="filled">
           {error}
         </Alert>
       </Snackbar>


### PR DESCRIPTION
Closes #17

## 変更内容
- ファイル名に日付を追加 (my-top3-YYYY-MM-DD-テーマ.png)
- ダウンロード成功時のSnackbar通知
- エラーハンドリングの改善（エラーもSnackbar表示に変更）
- テストの更新（日付付きファイル名の検証、Snackbarボタンとの競合修正）
