### PR TITLE
feat: SearchPageレイアウト刷新 (#41)

### DIFF
--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -31,7 +31,7 @@ function SlotCard({
   if (!item) {
     return (
       <div
-        className="flex h-16 flex-1 flex-col items-center justify-center rounded-lg border-2 border-dashed p-2 sm:h-24"
+        className="flex h-20 flex-1 flex-col items-center justify-center rounded-xl border-2 border-dashed p-2 transition-colors sm:h-28"
         style={{
           borderColor: 'var(--color-border)',
           backgroundColor: 'var(--color-surface)',
@@ -39,6 +39,7 @@ function SlotCard({
       >
         <Typography
           variant="caption"
+          sx={{ fontSize: '0.75rem', fontWeight: 600 }}
           style={{ color: 'var(--color-text-secondary)' }}
         >
           {CATEGORY_LABELS[category]}
@@ -55,7 +56,7 @@ function SlotCard({
 
   return (
     <div
-      className="relative flex h-16 flex-1 items-center gap-2 rounded-lg border p-2 sm:h-24"
+      className="relative flex h-20 flex-1 items-center gap-2 rounded-xl border-2 p-2 transition-colors sm:h-28"
       style={{
         borderColor: 'var(--color-border)',
         backgroundColor: 'var(--color-surface)',
@@ -109,6 +110,10 @@ function SelectionArea({ theme, onBeforeCreate }: SelectionAreaProps) {
   const { selection, deselectItem, isComplete } = useSelection()
   const navigate = useNavigate()
 
+  const selectedCount = (
+    [selection.book, selection.music, selection.movie] as const
+  ).filter(Boolean).length
+
   const handleCreate = () => {
     onBeforeCreate?.()
     const url = buildTop3Url(selection, theme)
@@ -117,6 +122,22 @@ function SelectionArea({ theme, onBeforeCreate }: SelectionAreaProps) {
 
   return (
     <Box>
+      <div className="mb-2 flex items-center justify-between">
+        <Typography
+          variant="subtitle2"
+          sx={{ fontWeight: 700, fontSize: '0.85rem' }}
+          style={{ color: 'var(--color-primary-dark)' }}
+        >
+          選択中の作品
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{ fontWeight: 600, fontSize: '0.75rem' }}
+          style={{ color: 'var(--color-primary)' }}
+        >
+          {selectedCount} / 3
+        </Typography>
+      </div>
       <div className="flex flex-col gap-2 sm:flex-row">
         <SlotCard
           category="book"

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -82,58 +82,86 @@ function SearchPage() {
     <div
       className="min-h-screen"
       style={{
-        background: 'linear-gradient(180deg, var(--color-bg) 0%, #ecfdf5 100%)',
+        background:
+          'linear-gradient(180deg, var(--color-primary-dark) 0%, var(--color-bg) 32%, #ecfdf5 100%)',
       }}
     >
-      <div className="mx-auto max-w-3xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
+      {/* Hero Section */}
+      <div className="px-3 pb-6 pt-8 text-center sm:px-4 sm:pb-8 sm:pt-12">
         <h1
-          className="text-xl font-extrabold sm:text-2xl"
+          className="text-3xl font-extrabold tracking-tight sm:text-4xl"
           style={{
             fontFamily: 'var(--font-display)',
-            color: 'var(--color-primary-dark)',
+            color: '#fff',
           }}
         >
           My Top 3
         </h1>
         <p
-          className="mt-1 text-sm sm:mt-2 sm:text-base"
-          style={{ color: 'var(--color-text-secondary)' }}
+          className="mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"
+          style={{ color: 'rgba(255,255,255,0.8)' }}
         >
           テーマを決めて、お気に入りの3作品を選ぼう
         </p>
+      </div>
 
-        {/* Theme Input Area */}
-        <div className="mt-6">
+      <div className="mx-auto max-w-3xl px-3 sm:px-4">
+        {/* Theme Input Section */}
+        <div
+          className="rounded-xl p-4 shadow-sm sm:p-5"
+          style={{
+            backgroundColor: 'var(--color-surface)',
+            border: '1px solid var(--color-border)',
+          }}
+        >
           <ThemeInput value={theme} onChange={setTheme} />
           <ThemeHistory onSelect={handleThemeHistorySelect} />
         </div>
 
-        {/* Selection Area */}
-        <div className="mt-4">
+        {/* Selection Area - Sticky */}
+        <div
+          className="sticky z-30 -mx-3 mt-5 px-3 pb-3 pt-2 sm:-mx-4 sm:px-4"
+          style={{
+            top: 0,
+            backdropFilter: 'blur(12px)',
+            WebkitBackdropFilter: 'blur(12px)',
+            backgroundColor: 'rgba(255,255,255,0.75)',
+          }}
+        >
           <SelectionArea theme={theme} onBeforeCreate={handleBeforeCreate} />
         </div>
 
-        {/* Tab Switcher */}
-        <TabSwitcher value={activeTab} onChange={setActiveTab} />
+        {/* Search Section Card */}
+        <div
+          className="mt-4 rounded-xl p-4 shadow-sm sm:p-5"
+          style={{
+            backgroundColor: 'var(--color-surface)',
+            border: '1px solid var(--color-border)',
+          }}
+        >
+          <TabSwitcher value={activeTab} onChange={setActiveTab} />
+          <SearchBar value={currentQuery} onChange={handleQueryChange} />
 
-        {/* Search Bar */}
-        <SearchBar value={currentQuery} onChange={handleQueryChange} />
+          {!currentQuery.trim() && (
+            <SearchHistory
+              category={activeTab}
+              onSearch={handleHistorySearch}
+            />
+          )}
 
-        {/* Search History (shown when search bar is empty) */}
-        {!currentQuery.trim() && (
-          <SearchHistory category={activeTab} onSearch={handleHistorySearch} />
-        )}
+          <SearchResults
+            results={results}
+            isLoading={isLoading}
+            hasMore={hasMore}
+            onLoadMore={loadMore}
+            onSelect={handleSelect}
+            query={debouncedQuery}
+            error={error}
+          />
+        </div>
 
-        {/* Search Results */}
-        <SearchResults
-          results={results}
-          isLoading={isLoading}
-          hasMore={hasMore}
-          onLoadMore={loadMore}
-          onSelect={handleSelect}
-          query={debouncedQuery}
-          error={error}
-        />
+        {/* Bottom spacer */}
+        <div className="h-8 sm:h-12" />
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #41

## 変更内容
- ヒーローセクションの追加（大きなタイトル、グラデーション背景）
- 選択エリアの強化（スロット拡大 h-20/sm:h-28、プログレス表示 n/3）
- セクションのカード化によるグルーピング（テーマ入力・検索セクション）
- sticky選択エリア（スクロール時に上部固定、blur背景）

## 変更ファイル
- `src/pages/SearchPage.tsx` - レイアウト再構成
- `src/components/SelectionArea.tsx` - スロット拡大・プログレス表示
