### PR TITLE
feat: Top3Page・Top3Imageのビジュアル強化 (#42)

### DIFF
--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -291,7 +291,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
               transform: 'translateX(-50%)',
               width: 200,
               height: 3,
-              background: 'linear-gradient(90deg, transparent, rgba(250,204,21,0.6), transparent)',
+              background:
+                'linear-gradient(90deg, transparent, rgba(250,204,21,0.6), transparent)',
               borderRadius: 2,
             }}
           />
@@ -352,7 +353,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
               left: 20,
               width: 1,
               height: 120,
-              background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.06), transparent)',
+              background:
+                'linear-gradient(180deg, transparent, rgba(255,255,255,0.06), transparent)',
             }}
           />
           <div
@@ -362,7 +364,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
               right: 20,
               width: 1,
               height: 120,
-              background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.06), transparent)',
+              background:
+                'linear-gradient(180deg, transparent, rgba(255,255,255,0.06), transparent)',
             }}
           />
 
@@ -378,7 +381,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
               style={{
                 width: 60,
                 height: 2,
-                background: 'linear-gradient(90deg, transparent, rgba(250,204,21,0.5), transparent)',
+                background:
+                  'linear-gradient(90deg, transparent, rgba(250,204,21,0.5), transparent)',
                 margin: '0 auto 16px',
                 borderRadius: 1,
               }}
@@ -411,7 +415,8 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
               style={{
                 width: 60,
                 height: 2,
-                background: 'linear-gradient(90deg, transparent, rgba(250,204,21,0.5), transparent)',
+                background:
+                  'linear-gradient(90deg, transparent, rgba(250,204,21,0.5), transparent)',
                 margin: '16px auto 0',
                 borderRadius: 1,
               }}

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -185,7 +185,8 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
         className="pointer-events-none absolute inset-0 rounded-xl"
         style={{
           border: '2px solid var(--color-border)',
-          borderImage: 'linear-gradient(135deg, var(--color-primary), var(--color-secondary)) 1',
+          borderImage:
+            'linear-gradient(135deg, var(--color-primary), var(--color-secondary)) 1',
           borderRadius: 'inherit',
           mask: 'linear-gradient(#fff 0 0)',
           WebkitMask: 'linear-gradient(#fff 0 0)',
@@ -195,7 +196,8 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
       <div
         className="mb-1.5 rounded-md px-3 py-1"
         style={{
-          background: 'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
+          background:
+            'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
         }}
       >
         <Typography
@@ -251,7 +253,11 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
       <Typography
         variant="caption"
         className="text-center"
-        sx={{ fontSize: '0.7rem', color: 'var(--color-text-secondary)', mt: 0.25 }}
+        sx={{
+          fontSize: '0.7rem',
+          color: 'var(--color-text-secondary)',
+          mt: 0.25,
+        }}
       >
         {work.subtitle}
       </Typography>
@@ -318,14 +324,16 @@ function Top3Page() {
           <div
             className="mx-auto mb-2 h-0.5 w-16 rounded-full"
             style={{
-              background: 'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
+              background:
+                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
             }}
           />
           <h1
             className="text-xl font-extrabold sm:text-2xl"
             style={{
               fontFamily: 'var(--font-display)',
-              background: 'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
+              background:
+                'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
               WebkitBackgroundClip: 'text',
               WebkitTextFillColor: 'transparent',
               backgroundClip: 'text',
@@ -336,7 +344,8 @@ function Top3Page() {
           <div
             className="mx-auto mt-2 h-0.5 w-16 rounded-full"
             style={{
-              background: 'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
+              background:
+                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
             }}
           />
         </div>


### PR DESCRIPTION
Closes #42

## 変更内容
- Top3Page: WorkCardのデザイン強化 (グラデーション, シャドウ, ホバー)
- Top3Page: テーマ表示の装飾 (デコラティブクォート, ライン)
- Top3Page: ランクバッジをゴールドカラーで目立たせ
- Top3Page: 「トップページに戻る」ボタンをピル型に改善
- Top3Image: 背景グラデーションの改善 (メッシュ風の複数radial-gradient)
- Top3Image: ブランドフッター (my-top3.app) 追加
- Top3Image: ランクバッジの拡大・ゴールドグロー装飾
- Top3Image: デコラティブ要素 (ライン, ドット) 追加
- Top3Image: タイポグラフィサイズの改善
