### PR TITLE
Rename: My Top 3 → My No.1s

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('search page loads', async ({ page }) => {
   await page.goto('/')
-  await expect(page).toHaveTitle(/My Top 3/)
+  await expect(page).toHaveTitle(/My No.1s/)
 })
 
 test('tab switching works', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <title>My Top 3</title>
+    <title>My No.1s</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ function App() {
       <SelectionProvider>
         <Routes>
           <Route path="/" element={<SearchPage />} />
-          <Route path="/my-top3" element={<Top3Page />} />
+          <Route path="/my-no1s" element={<Top3Page />} />
         </Routes>
       </SelectionProvider>
     </ErrorBoundary>

--- a/src/components/ShareButtons.test.tsx
+++ b/src/components/ShareButtons.test.tsx
@@ -104,26 +104,26 @@ describe('ShareButtons', () => {
     )
   })
 
-  it('includes theme and #MyTop3 hashtag in X share text', () => {
+  it('includes theme and #MyNo1s hashtag in X share text', () => {
     vi.spyOn(window, 'open').mockReturnValue({} as Window)
     render(<ShareButtons theme="雨の日に" />)
     fireEvent.click(screen.getByText('Xでシェア'))
 
     const url = (window.open as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as string
-    expect(url).toContain(encodeURIComponent('My Top 3 「雨の日に」'))
-    expect(url).toContain(encodeURIComponent('#MyTop3'))
+    expect(url).toContain(encodeURIComponent('My No.1s 「雨の日に」'))
+    expect(url).toContain(encodeURIComponent('#MyNo1s'))
   })
 
-  it('includes #MyTop3 hashtag when theme is not provided', () => {
+  it('includes #MyNo1s hashtag when theme is not provided', () => {
     vi.spyOn(window, 'open').mockReturnValue({} as Window)
     render(<ShareButtons />)
     fireEvent.click(screen.getByText('Xでシェア'))
 
     const url = (window.open as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as string
-    expect(url).toContain(encodeURIComponent('My Top 3'))
-    expect(url).toContain(encodeURIComponent('#MyTop3'))
+    expect(url).toContain(encodeURIComponent('My No.1s'))
+    expect(url).toContain(encodeURIComponent('#MyNo1s'))
     expect(url).not.toContain(encodeURIComponent('「'))
   })
 
@@ -172,8 +172,8 @@ describe('ShareButtons', () => {
 
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
-          title: 'My Top 3',
-          text: 'My Top 3 「雨の日に」 #MyTop3',
+          title: 'My No.1s',
+          text: 'My No.1s 「雨の日に」 #MyNo1s',
           url: window.location.href,
         })
       })
@@ -188,8 +188,8 @@ describe('ShareButtons', () => {
 
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
-          title: 'My Top 3',
-          text: 'My Top 3 #MyTop3',
+          title: 'My No.1s',
+          text: 'My No.1s #MyNo1s',
           url: window.location.href,
         })
       })

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -11,8 +11,8 @@ type ShareButtonsProps = {
 }
 
 function buildShareText(theme?: string): string {
-  const base = theme ? `My Top 3 「${theme}」` : 'My Top 3'
-  return `${base} #MyTop3`
+  const base = theme ? `My No.1s 「${theme}」` : 'My No.1s'
+  return `${base} #MyNo1s`
 }
 
 export default function ShareButtons({ theme }: ShareButtonsProps) {
@@ -64,7 +64,7 @@ export default function ShareButtons({ theme }: ShareButtonsProps) {
   const handleWebShare = useCallback(async () => {
     try {
       await navigator.share({
-        title: 'My Top 3',
+        title: 'My No.1s',
         text: buildShareText(theme),
         url: window.location.href,
       })

--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -248,7 +248,7 @@ describe('Top3Image', () => {
       })
 
       await waitFor(() => {
-        expect(getDownload()).toBe(`my-top3-${getTodayDate()}-テストテーマ.png`)
+        expect(getDownload()).toBe(`my-no1s-${getTodayDate()}-テストテーマ.png`)
       })
     })
 
@@ -273,7 +273,7 @@ describe('Top3Image', () => {
 
       await waitFor(() => {
         expect(getDownload()).toBe(
-          `my-top3-${getTodayDate()}-test_path_name__bad.png`,
+          `my-no1s-${getTodayDate()}-test_path_name__bad.png`,
         )
       })
     })

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -232,7 +232,7 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
       const date = formatDate()
       const safeTheme = theme ? `-${sanitizeFilename(theme)}` : ''
       const link = document.createElement('a')
-      link.download = `my-top3-${date}${safeTheme}.png`
+      link.download = `my-no1s-${date}${safeTheme}.png`
       link.href = dataUrl
       link.click()
       setSuccessOpen(true)
@@ -396,7 +396,7 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
                 textShadow: '0 2px 12px rgba(0,0,0,0.3)',
               }}
             >
-              My Top 3
+              My No.1s
             </div>
             {theme && (
               <div
@@ -454,7 +454,7 @@ function Top3Image({ theme, book, music, movie }: Top3ImageProps) {
                 fontWeight: 500,
               }}
             >
-              my-top3.app
+              my-no1s.app
             </span>
           </div>
         </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -106,7 +106,7 @@ function SearchPage() {
             color: '#fff',
           }}
         >
-          My Top 3
+          My No.1s
         </h1>
         <p
           className="mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -339,7 +339,7 @@ function Top3Page() {
               backgroundClip: 'text',
             }}
           >
-            My Top 3
+            My No.1s
           </h1>
           <div
             className="mx-auto mt-2 h-0.5 w-16 rounded-full"

--- a/src/utils/url-params.test.ts
+++ b/src/utils/url-params.test.ts
@@ -10,7 +10,7 @@ describe('buildTop3Url', () => {
       movie: createSearchResultItem({ id: 'v1', category: 'movie' }),
     }
     const url = buildTop3Url(selection, '雨の日に楽しむ')
-    expect(url).toContain('/my-top3?')
+    expect(url).toContain('/my-no1s?')
     expect(url).toContain('theme=')
     expect(url).toContain('book=b1')
     expect(url).toContain('music=m1')
@@ -45,9 +45,9 @@ describe('buildTop3Url', () => {
     expect(url).not.toContain('movie=')
   })
 
-  it('returns /my-top3 with no selections and no theme', () => {
+  it('returns /my-no1s with no selections and no theme', () => {
     const selection = { book: null, music: null, movie: null }
-    expect(buildTop3Url(selection, '')).toBe('/my-top3')
+    expect(buildTop3Url(selection, '')).toBe('/my-no1s')
   })
 
   it('trims theme whitespace', () => {

--- a/src/utils/url-params.ts
+++ b/src/utils/url-params.ts
@@ -33,7 +33,7 @@ export function buildTop3Url(selection: Selection, theme: string): string {
   }
 
   const queryString = params.toString()
-  return queryString ? `/my-top3?${queryString}` : '/my-top3'
+  return queryString ? `/my-no1s?${queryString}` : '/my-no1s'
 }
 
 const MAX_THEME_URL_LENGTH = 100


### PR DESCRIPTION
サービス表示名を My Top 3 から My No.1s に変更

- ページタイトル・見出し
- ハッシュタグ #MyTop3 → #MyNo1s
- URLパス /my-top3 → /my-no1s
- ダウンロードファイル名 my-top3 → my-no1s
- ウォーターマーク my-top3.app → my-no1s.app
- テスト更新済み（175件パス）