### PR TITLE
fix: 映画検索結果のsubtitleに公開年を表示する (#62)

### DIFF
--- a/src/services/tmdb.test.ts
+++ b/src/services/tmdb.test.ts
@@ -61,6 +61,41 @@ describe('searchMovies', () => {
       expect(result.data.items[0].category).toBe('movie')
       expect(result.data.items[0].title).toBe('Test Movie')
       expect(result.data.items[0].thumbnailUrl).toContain('/poster.jpg')
+      expect(result.data.items[0].subtitle).toBe('2024')
+    }
+  })
+
+  it('shows 公開日不明 when release_date is missing', async () => {
+    server.use(
+      http.get(`${BASE_URL}/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [mockMovie({ release_date: undefined })],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    )
+    const result = await searchMovies('key', 'test')
+    if (result.ok) {
+      expect(result.data.items[0].subtitle).toBe('公開日不明')
+    }
+  })
+
+  it('shows 公開日不明 when release_date is empty string', async () => {
+    server.use(
+      http.get(`${BASE_URL}/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [mockMovie({ release_date: '' })],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    )
+    const result = await searchMovies('key', 'test')
+    if (result.ok) {
+      expect(result.data.items[0].subtitle).toBe('公開日不明')
     }
   })
 

--- a/src/services/tmdb.ts
+++ b/src/services/tmdb.ts
@@ -179,11 +179,12 @@ export async function getMovieById(
 // ── Mapping ─────────────────────────────────────────────────────────
 
 function mapMovieToSearchResult(movie: TMDbMovie): SearchResultItem {
+  const releaseYear = movie.release_date?.split('-')[0]
   return {
     id: String(movie.id),
     category: 'movie',
     title: movie.title || 'タイトル不明',
-    subtitle: '監督不明',
+    subtitle: releaseYear || '公開日不明',
     thumbnailUrl: movie.poster_path
       ? `${IMAGE_BASE_URL}${movie.poster_path}`
       : '',


### PR DESCRIPTION
## 修正内容

Closes #62

### 問題
`searchMovies` の `mapMovieToSearchResult` が常に `subtitle: '監督不明'` を返していた。
TMDb `/search/movie` APIのレスポンスには `credits` が含まれないため、監督名を取得できない。

### 解決策（案2: release_date を表示）
追加APIコールを避け、検索結果の subtitle には `release_date` から抽出した公開年を表示する。
- 公開年がある場合: 例 `2024`
- `release_date` がない/空の場合: `公開日不明`

映画選択後の Top3 ページでは `getMovieById` が `credits` を含めて取得するため、監督名は正しく表示される。

### 変更ファイル
- `src/services/tmdb.ts`: `mapMovieToSearchResult` を修正
- `src/services/tmdb.test.ts`: 公開年表示・公開日不明のテストを追加

### テスト結果
全180テスト通過 ✅