### PR TITLE
feat: CORSミドルウェアを設定する (#63)

### DIFF
--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest'
+import app from './index'
+
+vi.mock('../services/google-books.ts', () => ({
+  searchBooks: vi.fn(),
+  getBookById: vi.fn(),
+}))
+vi.mock('../services/spotify.ts', () => ({
+  searchMusic: vi.fn(),
+  getMusicById: vi.fn(),
+}))
+vi.mock('../services/tmdb.ts', () => ({
+  searchMovies: vi.fn(),
+  getMovieById: vi.fn(),
+}))
+
+describe('CORS middleware', () => {
+  it('returns CORS headers for /api/* with allowed origin', async () => {
+    const req = new Request('http://localhost/api/books/search?q=test', {
+      headers: { Origin: 'https://myno1s.exe.xyz' },
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://myno1s.exe.xyz',
+    )
+  })
+
+  it('handles preflight OPTIONS request', async () => {
+    const req = new Request('http://localhost/api/books/search', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://myno1s.exe.xyz',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://myno1s.exe.xyz',
+    )
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET')
+  })
+
+  it('does not return CORS headers for disallowed origin', async () => {
+    const req = new Request('http://localhost/api/books/search?q=test', {
+      headers: { Origin: 'https://evil.example.com' },
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import { booksApp } from './routes/books.ts'
 import { musicApp } from './routes/music.ts'
 import { moviesApp } from './routes/movies.ts'
@@ -25,6 +26,14 @@ if (!process.env['TMDB_API_KEY']) {
 }
 
 const app = new Hono()
+
+app.use(
+  '/api/*',
+  cors({
+    origin: ['https://myno1s.exe.xyz'],
+    allowMethods: ['GET'],
+  }),
+)
 
 app.route('/api/books', booksApp)
 app.route('/api/music', musicApp)


### PR DESCRIPTION
## 概要
HonoサーバーにCORSミドルウェアを追加。

## 変更内容
- `hono/cors` ミドルウェアを `/api/*` に適用
- 許可オリジン: `https://myno1s.exe.xyz`
- 許可メソッド: GET のみ

Closes #63