### PR TITLE
feat: 検索クエリの長さに上限を設ける (#64)

### DIFF
--- a/src/server/middleware/validate-search.test.ts
+++ b/src/server/middleware/validate-search.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import {
+  validateSearchQuery,
+  clampStartIndex,
+  MAX_QUERY_LENGTH,
+  MAX_START_INDEX,
+} from './validate-search'
+
+describe('validateSearchQuery', () => {
+  it('returns null for valid query', () => {
+    expect(validateSearchQuery('hello')).toBeNull()
+  })
+
+  it('returns error message for too long query', () => {
+    const longQuery = 'a'.repeat(MAX_QUERY_LENGTH + 1)
+    expect(validateSearchQuery(longQuery)).toContain('Query too long')
+  })
+
+  it('allows query at exact max length', () => {
+    expect(validateSearchQuery('a'.repeat(MAX_QUERY_LENGTH))).toBeNull()
+  })
+})
+
+describe('clampStartIndex', () => {
+  it('returns 0 for empty string', () => {
+    expect(clampStartIndex('')).toBe(0)
+  })
+
+  it('clamps negative to 0', () => {
+    expect(clampStartIndex('-5')).toBe(0)
+  })
+
+  it('clamps excessive values to MAX_START_INDEX', () => {
+    expect(clampStartIndex('999999')).toBe(MAX_START_INDEX)
+  })
+
+  it('passes through valid values', () => {
+    expect(clampStartIndex('50')).toBe(50)
+  })
+})

--- a/src/server/middleware/validate-search.ts
+++ b/src/server/middleware/validate-search.ts
@@ -1,0 +1,16 @@
+const MAX_QUERY_LENGTH = 200
+const MAX_START_INDEX = 10000
+
+export function validateSearchQuery(query: string): string | null {
+  if (query.length > MAX_QUERY_LENGTH) {
+    return `Query too long (max ${MAX_QUERY_LENGTH} characters)`
+  }
+  return null
+}
+
+export function clampStartIndex(raw: string): number {
+  const value = Number(raw) || 0
+  return Math.max(0, Math.min(MAX_START_INDEX, value))
+}
+
+export { MAX_QUERY_LENGTH, MAX_START_INDEX }

--- a/src/server/routes/books.test.ts
+++ b/src/server/routes/books.test.ts
@@ -65,6 +65,12 @@ describe('books routes', () => {
       expect(res.status).toBe(429)
     })
 
+    it('returns 400 for too long query', async () => {
+      const longQuery = 'a'.repeat(201)
+      const res = await booksApp.request(`/search?q=${longQuery}`)
+      expect(res.status).toBe(400)
+    })
+
     it('clamps maxResults between 1-40', async () => {
       mockSearchBooks.mockResolvedValue({
         ok: true,

--- a/src/server/routes/books.ts
+++ b/src/server/routes/books.ts
@@ -1,6 +1,10 @@
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { Hono } from 'hono'
 import { searchBooks, getBookById } from '../../services/google-books.ts'
+import {
+  validateSearchQuery,
+  clampStartIndex,
+} from '../middleware/validate-search.ts'
 
 const app = new Hono()
 
@@ -23,10 +27,14 @@ app.get('/search', async (c) => {
     }
 
     const query = c.req.query('q') ?? ''
-    const startIndex = Math.max(
-      0,
-      Number(c.req.query('startIndex') ?? '0') || 0,
-    )
+    const queryError = validateSearchQuery(query)
+    if (queryError) {
+      return c.json(
+        { ok: false, error: { kind: 'unknown', message: queryError } },
+        400,
+      )
+    }
+    const startIndex = clampStartIndex(c.req.query('startIndex') ?? '0')
     const maxResults = Math.max(
       1,
       Math.min(40, Number(c.req.query('maxResults') ?? '20') || 20),

--- a/src/server/routes/movies.test.ts
+++ b/src/server/routes/movies.test.ts
@@ -49,6 +49,12 @@ describe('movies routes', () => {
       expect(body.ok).toBe(true)
     })
 
+    it('returns 400 for too long query', async () => {
+      const longQuery = 'a'.repeat(201)
+      const res = await moviesApp.request(`/search?q=${longQuery}`)
+      expect(res.status).toBe(400)
+    })
+
     it('returns error status on service failure', async () => {
       mockSearchMovies.mockResolvedValue({
         ok: false,

--- a/src/server/routes/movies.ts
+++ b/src/server/routes/movies.ts
@@ -1,6 +1,10 @@
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { Hono } from 'hono'
 import { searchMovies, getMovieById } from '../../services/tmdb.ts'
+import {
+  validateSearchQuery,
+  clampStartIndex,
+} from '../middleware/validate-search.ts'
 
 const app = new Hono()
 
@@ -23,10 +27,14 @@ app.get('/search', async (c) => {
     }
 
     const query = c.req.query('q') ?? ''
-    const startIndex = Math.max(
-      0,
-      Number(c.req.query('startIndex') ?? '0') || 0,
-    )
+    const queryError = validateSearchQuery(query)
+    if (queryError) {
+      return c.json(
+        { ok: false, error: { kind: 'unknown', message: queryError } },
+        400,
+      )
+    }
+    const startIndex = clampStartIndex(c.req.query('startIndex') ?? '0')
     const maxResults = Math.max(
       1,
       Math.min(40, Number(c.req.query('maxResults') ?? '20') || 20),

--- a/src/server/routes/music.test.ts
+++ b/src/server/routes/music.test.ts
@@ -57,6 +57,12 @@ describe('music routes', () => {
       expect(body.ok).toBe(true)
     })
 
+    it('returns 400 for too long query', async () => {
+      const longQuery = 'a'.repeat(201)
+      const res = await musicApp.request(`/search?q=${longQuery}`)
+      expect(res.status).toBe(400)
+    })
+
     it('returns error when token fetch fails', async () => {
       mockGetAccessToken.mockResolvedValue({
         ok: false,

--- a/src/server/routes/music.ts
+++ b/src/server/routes/music.ts
@@ -5,6 +5,10 @@ import {
   searchMusic,
   getMusicById,
 } from '../../services/spotify.ts'
+import {
+  validateSearchQuery,
+  clampStartIndex,
+} from '../middleware/validate-search.ts'
 
 const app = new Hono()
 
@@ -46,10 +50,14 @@ app.get('/search', async (c) => {
     }
 
     const query = c.req.query('q') ?? ''
-    const startIndex = Math.max(
-      0,
-      Number(c.req.query('startIndex') ?? '0') || 0,
-    )
+    const queryError = validateSearchQuery(query)
+    if (queryError) {
+      return c.json(
+        { ok: false, error: { kind: 'unknown', message: queryError } },
+        400,
+      )
+    }
+    const startIndex = clampStartIndex(c.req.query('startIndex') ?? '0')
     const maxResults = Math.max(
       1,
       Math.min(10, Number(c.req.query('maxResults') ?? '10') || 10),


### PR DESCRIPTION
## 概要
検索クエリとstartIndexにバリデーションを追加。

## 変更内容
- qパラメータに最大200文字の制限を追加
- startIndexに最大10000の上限を設定
- バリデーション失敗時は400 Bad Requestを返却
- 共通バリデーションヘルパーを作成

Closes #64