### PR TITLE
fix: Spotifyトークンキャッシュのレースコンディションを修正する (#65)

### DIFF
--- a/src/services/spotify.test.ts
+++ b/src/services/spotify.test.ts
@@ -44,6 +44,27 @@ describe('getAccessToken', () => {
     vi.resetModules()
   })
 
+  it('deduplicates concurrent token requests', async () => {
+    let tokenCallCount = 0
+    server.use(
+      http.post(TOKEN_URL, () => {
+        tokenCallCount++
+        return HttpResponse.json(mockTokenResponse())
+      }),
+    )
+    const { getAccessToken } = await import('./spotify')
+    // Call concurrently
+    const results = await Promise.all([
+      getAccessToken('client-id', 'client-secret'),
+      getAccessToken('client-id', 'client-secret'),
+      getAccessToken('client-id', 'client-secret'),
+    ])
+    // All should succeed
+    expect(results.every((r) => r.ok)).toBe(true)
+    // But only 1 actual HTTP request should have been made
+    expect(tokenCallCount).toBe(1)
+  })
+
   it('returns token on success', async () => {
     server.use(
       http.post(TOKEN_URL, () => HttpResponse.json(mockTokenResponse())),

--- a/src/services/spotify.ts
+++ b/src/services/spotify.ts
@@ -58,6 +58,7 @@ type SpotifyTokenResponse = {
 
 let cachedToken: string | null = null
 let tokenExpiresAt = 0
+let tokenPromise: Promise<Result<string>> | null = null
 
 export async function getAccessToken(
   clientId: string,
@@ -68,6 +69,21 @@ export async function getAccessToken(
     return { ok: true, data: cachedToken }
   }
 
+  if (tokenPromise) {
+    return tokenPromise
+  }
+
+  tokenPromise = fetchNewToken(clientId, clientSecret).finally(() => {
+    tokenPromise = null
+  })
+
+  return tokenPromise
+}
+
+async function fetchNewToken(
+  clientId: string,
+  clientSecret: string,
+): Promise<Result<string>> {
   const credentials = btoa(`${clientId}:${clientSecret}`)
 
   const result = await fetchJson<SpotifyTokenResponse>(TOKEN_URL, {
@@ -83,8 +99,7 @@ export async function getAccessToken(
   if (!result.ok) return result
 
   cachedToken = result.data.access_token
-  // Refresh 60 seconds before actual expiry
-  tokenExpiresAt = now + (result.data.expires_in - 60) * 1000
+  tokenExpiresAt = Date.now() + (result.data.expires_in - 60) * 1000
 
   return { ok: true, data: cachedToken }
 }


### PR DESCRIPTION
## 概要
Spotifyトークン取得時の並行リクエストのレースコンディションを修正。

## 変更内容
- Promiseベースのキャッシュに変更し、同時リクエスト時は1つのPromiseを共有
- トークンリフレッシュ中の追加リクエストは既存のPromiseを返却
- 不要な複数回のトークンリクエストを防止

Closes #65