### PR TITLE
refactor: vite.config.ts の環境変数設定を明示的にする (#74)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,22 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import devServer from '@hono/vite-dev-server'
 
-// https://vite.dev/config/
+const API_ENV_KEYS = [
+  'GOOGLE_BOOKS_API_KEY',
+  'SPOTIFY_CLIENT_ID',
+  'SPOTIFY_CLIENT_SECRET',
+  'TMDB_API_KEY',
+] as const
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  Object.assign(process.env, env)
+
+  // Only set the specific API keys needed by the dev server
+  for (const key of API_ENV_KEYS) {
+    if (env[key]) {
+      process.env[key] = env[key]
+    }
+  }
 
   return {
     server: {


### PR DESCRIPTION
## 概要
vite.config.tsでprocess.envへの全環境変数の一括代入を廃止。

## 変更内容
- Object.assign(process.env, env) を削除
- APIサーバーに必要な4つのキーのみを明示的に設定
- 意図しない環境変数の上書きを防止

Closes #74