### PR TITLE
refactor: useIntersectionObserver の options による不要な再生成を防ぐ (#75)

### DIFF
--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -2,7 +2,8 @@ import { useRef, useCallback, useEffect } from 'react'
 
 export function useIntersectionObserver(
   callback: () => void,
-  options?: IntersectionObserverInit,
+  rootMargin = '200px',
+  threshold = 0,
 ): (node: HTMLDivElement | null) => void {
   const callbackRef = useRef(callback)
   useEffect(() => {
@@ -29,16 +30,15 @@ export function useIntersectionObserver(
         },
         {
           root: null,
-          rootMargin: '200px',
-          threshold: 0,
-          ...options,
+          rootMargin,
+          threshold,
         },
       )
 
       observer.observe(node)
       observerRef.current = observer
     },
-    [options],
+    [rootMargin, threshold],
   )
 
   return sentinelCallbackRef


### PR DESCRIPTION
## 概要
useIntersectionObserverのuseCallback依存配列からオブジェクト参照を除去。

## 変更内容
- optionsオブジェクトの代わりにrootMargin, thresholdをプリミティブ引数として受け取るように変更
- useCallbackの依存配列がプリミティブ値のみになり、不要なIntersectionObserver再生成を防止
- 既存の呼び出し元はデフォルト引数のみ使用しているため変更不要

Closes #75