### PR TITLE
refactor: useSearchHistory と useThemeHistory を汎用フックに統合する (#68)

### DIFF
--- a/src/hooks/useLocalStorageHistory.ts
+++ b/src/hooks/useLocalStorageHistory.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback } from 'react'
+
+const MAX_HISTORY_ITEMS = 10
+
+type HistoryItem<K extends string> = Record<K, string> & { timestamp: number }
+
+type UseLocalStorageHistoryReturn = {
+  history: string[]
+  addHistory: (value: string) => void
+  removeHistory: (value: string) => void
+  clearHistory: () => void
+}
+
+function isHistoryItem<K extends string>(
+  item: unknown,
+  fieldName: K,
+): item is HistoryItem<K> {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as Record<string, unknown>)[fieldName] === 'string' &&
+    typeof (item as Record<string, unknown>)['timestamp'] === 'number'
+  )
+}
+
+function loadHistory<K extends string>(
+  storageKey: string,
+  fieldName: K,
+  hookName: string,
+): HistoryItem<K>[] {
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      console.warn(
+        `[${hookName}] Invalid data format for "${storageKey}". Resetting.`,
+      )
+      localStorage.removeItem(storageKey)
+      return []
+    }
+    return parsed.filter((item): item is HistoryItem<K> =>
+      isHistoryItem(item, fieldName),
+    )
+  } catch (error) {
+    console.warn(`[${hookName}] Failed to load history:`, error)
+    return []
+  }
+}
+
+function saveHistory<K extends string>(
+  storageKey: string,
+  items: HistoryItem<K>[],
+  hookName: string,
+): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(items))
+  } catch (error) {
+    console.warn(`[${hookName}] Failed to save history:`, error)
+  }
+}
+
+function toValues<K extends string>(
+  items: HistoryItem<K>[],
+  fieldName: K,
+): string[] {
+  return [...items]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .map((item) => item[fieldName])
+}
+
+export function useLocalStorageHistory<K extends string>(
+  storageKey: string,
+  fieldName: K,
+  hookName: string,
+  deps: unknown[] = [],
+): UseLocalStorageHistoryReturn {
+  const [history, setHistory] = useState<string[]>(() =>
+    toValues(loadHistory(storageKey, fieldName, hookName), fieldName),
+  )
+
+  useEffect(() => {
+    setHistory(
+      toValues(loadHistory(storageKey, fieldName, hookName), fieldName),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey, fieldName, hookName, ...deps])
+
+  const addHistory = useCallback(
+    (value: string) => {
+      const trimmed = value.trim()
+      if (!trimmed) return
+
+      const items = loadHistory(storageKey, fieldName, hookName)
+      const filtered = items.filter((item) => item[fieldName] !== trimmed)
+      const newItem = {
+        [fieldName]: trimmed,
+        timestamp: Date.now(),
+      } as HistoryItem<K>
+      const newItems = [newItem, ...filtered].slice(0, MAX_HISTORY_ITEMS)
+
+      saveHistory(storageKey, newItems, hookName)
+      setHistory(toValues(newItems, fieldName))
+    },
+    [storageKey, fieldName, hookName],
+  )
+
+  const removeHistory = useCallback(
+    (value: string) => {
+      const items = loadHistory(storageKey, fieldName, hookName)
+      const filtered = items.filter((item) => item[fieldName] !== value)
+      saveHistory(storageKey, filtered, hookName)
+      setHistory(toValues(filtered, fieldName))
+    },
+    [storageKey, fieldName, hookName],
+  )
+
+  const clearHistory = useCallback(() => {
+    saveHistory(storageKey, [], hookName)
+    setHistory([])
+  }, [storageKey, hookName])
+
+  return { history, addHistory, removeHistory, clearHistory }
+}

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,13 +1,7 @@
-import { useState, useEffect, useCallback } from 'react'
 import type { MediaCategory } from '../types/common'
+import { useLocalStorageHistory } from './useLocalStorageHistory'
 
-const MAX_HISTORY_ITEMS = 10
 const STORAGE_KEY_PREFIX = 'search-history'
-
-type SearchHistoryItem = {
-  keyword: string
-  timestamp: number
-}
 
 type UseSearchHistoryReturn = {
   history: string[]
@@ -16,104 +10,13 @@ type UseSearchHistoryReturn = {
   clearHistory: () => void
 }
 
-function getStorageKey(category: MediaCategory): string {
-  return `${STORAGE_KEY_PREFIX}-${category}`
-}
-
-function isHistoryItem(item: unknown): item is SearchHistoryItem {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    typeof (item as SearchHistoryItem).keyword === 'string' &&
-    typeof (item as SearchHistoryItem).timestamp === 'number'
-  )
-}
-
-function loadHistory(category: MediaCategory): SearchHistoryItem[] {
-  try {
-    const raw = localStorage.getItem(getStorageKey(category))
-    if (!raw) return []
-    const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) {
-      console.warn(
-        `[useSearchHistory] Invalid data format for "${getStorageKey(category)}". Resetting.`,
-      )
-      localStorage.removeItem(getStorageKey(category))
-      return []
-    }
-    return parsed.filter(isHistoryItem)
-  } catch (error) {
-    console.warn(
-      `[useSearchHistory] Failed to load history for "${category}":`,
-      error,
-    )
-    return []
-  }
-}
-
-function saveHistory(
-  category: MediaCategory,
-  items: SearchHistoryItem[],
-): void {
-  try {
-    localStorage.setItem(getStorageKey(category), JSON.stringify(items))
-  } catch (error) {
-    console.warn(
-      `[useSearchHistory] Failed to save history for "${category}":`,
-      error,
-    )
-  }
-}
-
-function toKeywords(items: SearchHistoryItem[]): string[] {
-  return [...items]
-    .sort((a, b) => b.timestamp - a.timestamp)
-    .map((item) => item.keyword)
-}
-
 export function useSearchHistory(
   category: MediaCategory,
 ): UseSearchHistoryReturn {
-  const [history, setHistory] = useState<string[]>(() =>
-    toKeywords(loadHistory(category)),
-  )
-
-  useEffect(() => {
-    setHistory(toKeywords(loadHistory(category)))
-  }, [category])
-
-  const addHistory = useCallback(
-    (keyword: string) => {
-      const trimmed = keyword.trim()
-      if (!trimmed) return
-
-      const items = loadHistory(category)
-      const filtered = items.filter((item) => item.keyword !== trimmed)
-      const newItems = [
-        { keyword: trimmed, timestamp: Date.now() },
-        ...filtered,
-      ].slice(0, MAX_HISTORY_ITEMS)
-
-      saveHistory(category, newItems)
-      setHistory(toKeywords(newItems))
-    },
+  return useLocalStorageHistory(
+    `${STORAGE_KEY_PREFIX}-${category}`,
+    'keyword',
+    'useSearchHistory',
     [category],
   )
-
-  const removeHistory = useCallback(
-    (keyword: string) => {
-      const items = loadHistory(category)
-      const filtered = items.filter((item) => item.keyword !== keyword)
-      saveHistory(category, filtered)
-      setHistory(toKeywords(filtered))
-    },
-    [category],
-  )
-
-  const clearHistory = useCallback(() => {
-    saveHistory(category, [])
-    setHistory([])
-  }, [category])
-
-  return { history, addHistory, removeHistory, clearHistory }
 }

--- a/src/hooks/useThemeHistory.ts
+++ b/src/hooks/useThemeHistory.ts
@@ -1,12 +1,6 @@
-import { useState, useCallback } from 'react'
+import { useLocalStorageHistory } from './useLocalStorageHistory'
 
-const MAX_HISTORY_ITEMS = 10
 const STORAGE_KEY = 'theme-history'
-
-type ThemeHistoryItem = {
-  theme: string
-  timestamp: number
-}
 
 type UseThemeHistoryReturn = {
   history: string[]
@@ -15,79 +9,6 @@ type UseThemeHistoryReturn = {
   clearHistory: () => void
 }
 
-function isHistoryItem(item: unknown): item is ThemeHistoryItem {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    typeof (item as ThemeHistoryItem).theme === 'string' &&
-    typeof (item as ThemeHistoryItem).timestamp === 'number'
-  )
-}
-
-function loadHistory(): ThemeHistoryItem[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return []
-    const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) {
-      console.warn(
-        `[useThemeHistory] Invalid data format for "${STORAGE_KEY}". Resetting.`,
-      )
-      localStorage.removeItem(STORAGE_KEY)
-      return []
-    }
-    return parsed.filter(isHistoryItem)
-  } catch (error) {
-    console.warn('[useThemeHistory] Failed to load history:', error)
-    return []
-  }
-}
-
-function saveHistory(items: ThemeHistoryItem[]): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
-  } catch (error) {
-    console.warn('[useThemeHistory] Failed to save history:', error)
-  }
-}
-
-function toThemes(items: ThemeHistoryItem[]): string[] {
-  return [...items]
-    .sort((a, b) => b.timestamp - a.timestamp)
-    .map((item) => item.theme)
-}
-
 export function useThemeHistory(): UseThemeHistoryReturn {
-  const [history, setHistory] = useState<string[]>(() =>
-    toThemes(loadHistory()),
-  )
-
-  const addHistory = useCallback((theme: string) => {
-    const trimmed = theme.trim()
-    if (!trimmed) return
-
-    const items = loadHistory()
-    const filtered = items.filter((item) => item.theme !== trimmed)
-    const newItems = [
-      { theme: trimmed, timestamp: Date.now() },
-      ...filtered,
-    ].slice(0, MAX_HISTORY_ITEMS)
-
-    saveHistory(newItems)
-    setHistory(toThemes(newItems))
-  }, [])
-
-  const removeHistory = useCallback((theme: string) => {
-    const items = loadHistory()
-    const filtered = items.filter((item) => item.theme !== theme)
-    saveHistory(filtered)
-    setHistory(toThemes(filtered))
-  }, [])
-
-  const clearHistory = useCallback(() => {
-    saveHistory([])
-    setHistory([])
-  }, [])
-
-  return { history, addHistory, removeHistory, clearHistory }
+  return useLocalStorageHistory(STORAGE_KEY, 'theme', 'useThemeHistory')
 }


### PR DESCRIPTION
## 概要
重複していた2つの履歴管理フックを汎用的なuseLocalStorageHistoryフックに統合。

## 変更内容
- 汎用 useLocalStorageHistory フックを作成
- useSearchHistory と useThemeHistory をラッパーとしてリファクタリング
- 既存のテストは全てパス（外部APIは変更なし）

Closes #68