### PR TITLE
fix: SelectionArea の Top3を作成 ボタン重複を解消する (#73)

### DIFF
--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -162,7 +162,12 @@ function SelectionArea({
       </div>
       {isComplete && (
         <div className="mt-3 text-center">
-          <Button variant="contained" onClick={handleCreate} size="medium">
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            size="medium"
+            sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
+          >
             Top3を作成
           </Button>
         </div>
@@ -177,7 +182,7 @@ function SelectionArea({
             left: 0,
             right: 0,
             zIndex: 1200,
-            display: 'flex',
+            display: { xs: 'flex', sm: 'none' },
             justifyContent: 'center',
             pb: `max(12px, env(safe-area-inset-bottom))`,
             pt: 1.5,


### PR DESCRIPTION
## 概要
SelectionAreaのTop3を作成ボタンの重複をレスポンシブ表示に変更。

## 変更内容
- デスクトップ(sm以上): インラインボタンのみ表示
- モバイル(xs): FABのみ表示
- 同一画面にボタンが2つ表示される問題を解消

Closes #73