### PR TITLE
refactor: SearchPage.tsx の状態管理を useSearchPage フックに抽出する (#72)

### DIFF
--- a/src/hooks/useSearchPage.ts
+++ b/src/hooks/useSearchPage.ts
@@ -1,0 +1,115 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import type { MediaCategory, SearchResultItem } from '../types/common'
+import { useDebounce } from './useDebounce'
+import { useSearch } from './useSearch'
+import { useSearchHistory } from './useSearchHistory'
+import { useThemeHistory } from './useThemeHistory'
+import { useTheme } from './useTheme'
+import { useSelection } from './useSelection'
+
+type QueryState = Record<MediaCategory, string>
+
+const INITIAL_QUERIES: QueryState = {
+  book: '',
+  music: '',
+  movie: '',
+}
+
+export function useSearchPage() {
+  const [activeTab, setActiveTab] = useState<MediaCategory>('book')
+  const [queries, setQueries] = useState<QueryState>(INITIAL_QUERIES)
+  const { theme, setTheme } = useTheme()
+  const { selectItem } = useSelection()
+  const { addHistory: addThemeHistory } = useThemeHistory()
+
+  const currentQuery = queries[activeTab]
+  const debouncedQuery = useDebounce(currentQuery, 300)
+
+  const { results, isLoading, error, loadMore, hasMore } = useSearch(
+    activeTab,
+    debouncedQuery,
+  )
+
+  const { addHistory } = useSearchHistory(activeTab)
+  const prevDebouncedQueryRef = useRef(debouncedQuery)
+
+  useEffect(() => {
+    if (
+      debouncedQuery.trim() &&
+      debouncedQuery !== prevDebouncedQueryRef.current
+    ) {
+      addHistory(debouncedQuery.trim())
+    }
+    prevDebouncedQueryRef.current = debouncedQuery
+  }, [debouncedQuery, addHistory])
+
+  const handleQueryChange = useCallback(
+    (value: string) => {
+      setQueries((prev) => ({ ...prev, [activeTab]: value }))
+    },
+    [activeTab],
+  )
+
+  const handleHistorySearch = useCallback(
+    (keyword: string) => {
+      setQueries((prev) => ({ ...prev, [activeTab]: keyword }))
+    },
+    [activeTab],
+  )
+
+  const handleSelect = useCallback(
+    (item: SearchResultItem) => {
+      selectItem(item)
+    },
+    [selectItem],
+  )
+
+  const handleThemeHistorySelect = useCallback(
+    (selectedTheme: string) => {
+      setTheme(selectedTheme)
+    },
+    [setTheme],
+  )
+
+  const [selectionComplete, setSelectionComplete] = useState(false)
+
+  const handleBeforeCreate = useCallback(() => {
+    addThemeHistory(theme)
+  }, [theme, addThemeHistory])
+
+  const handleCompleteChange = useCallback((complete: boolean) => {
+    setSelectionComplete(complete)
+  }, [])
+
+  const mainStyle = useMemo(
+    () => ({
+      background:
+        'linear-gradient(180deg, var(--color-primary-dark) 0%, var(--color-bg) 32%, #ecfdf5 100%)',
+      paddingBottom: selectionComplete
+        ? 'calc(72px + env(safe-area-inset-bottom))'
+        : undefined,
+    }),
+    [selectionComplete],
+  )
+
+  return {
+    activeTab,
+    setActiveTab,
+    currentQuery,
+    debouncedQuery,
+    theme,
+    setTheme,
+    results,
+    isLoading,
+    error,
+    loadMore,
+    hasMore,
+    handleQueryChange,
+    handleHistorySearch,
+    handleSelect,
+    handleThemeHistorySelect,
+    handleBeforeCreate,
+    handleCompleteChange,
+    mainStyle,
+  }
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,11 +1,3 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import type { MediaCategory, SearchResultItem } from '../types/common'
-import { useDebounce } from '../hooks/useDebounce'
-import { useSearch } from '../hooks/useSearch'
-import { useSearchHistory } from '../hooks/useSearchHistory'
-import { useThemeHistory } from '../hooks/useThemeHistory'
-import { useTheme } from '../hooks/useTheme'
-import { useSelection } from '../hooks/useSelection'
 import TabSwitcher from '../components/TabSwitcher'
 import SearchBar from '../components/SearchBar'
 import SearchHistory from '../components/SearchHistory'
@@ -13,91 +5,29 @@ import SearchResults from '../components/SearchResults'
 import ThemeInput from '../components/ThemeInput'
 import ThemeHistory from '../components/ThemeHistory'
 import SelectionArea from '../components/SelectionArea'
-
-type QueryState = Record<MediaCategory, string>
-
-const INITIAL_QUERIES: QueryState = {
-  book: '',
-  music: '',
-  movie: '',
-}
+import { useSearchPage } from '../hooks/useSearchPage'
 
 function SearchPage() {
-  const [activeTab, setActiveTab] = useState<MediaCategory>('book')
-  const [queries, setQueries] = useState<QueryState>(INITIAL_QUERIES)
-  const { theme, setTheme } = useTheme()
-  const { selectItem } = useSelection()
-  const { addHistory: addThemeHistory } = useThemeHistory()
-
-  const currentQuery = queries[activeTab]
-  const debouncedQuery = useDebounce(currentQuery, 300)
-
-  const { results, isLoading, error, loadMore, hasMore } = useSearch(
+  const {
     activeTab,
+    setActiveTab,
+    currentQuery,
     debouncedQuery,
-  )
-
-  const { addHistory } = useSearchHistory(activeTab)
-  const prevDebouncedQueryRef = useRef(debouncedQuery)
-
-  useEffect(() => {
-    if (
-      debouncedQuery.trim() &&
-      debouncedQuery !== prevDebouncedQueryRef.current
-    ) {
-      addHistory(debouncedQuery.trim())
-    }
-    prevDebouncedQueryRef.current = debouncedQuery
-  }, [debouncedQuery, addHistory])
-
-  const handleQueryChange = useCallback(
-    (value: string) => {
-      setQueries((prev) => ({ ...prev, [activeTab]: value }))
-    },
-    [activeTab],
-  )
-
-  const handleHistorySearch = useCallback(
-    (keyword: string) => {
-      setQueries((prev) => ({ ...prev, [activeTab]: keyword }))
-    },
-    [activeTab],
-  )
-
-  const handleSelect = useCallback(
-    (item: SearchResultItem) => {
-      selectItem(item)
-    },
-    [selectItem],
-  )
-
-  const handleThemeHistorySelect = useCallback(
-    (selectedTheme: string) => {
-      setTheme(selectedTheme)
-    },
-    [setTheme],
-  )
-
-  const [selectionComplete, setSelectionComplete] = useState(false)
-
-  const handleBeforeCreate = useCallback(() => {
-    addThemeHistory(theme)
-  }, [theme, addThemeHistory])
-
-  const handleCompleteChange = useCallback((complete: boolean) => {
-    setSelectionComplete(complete)
-  }, [])
-
-  const mainStyle = useMemo(
-    () => ({
-      background:
-        'linear-gradient(180deg, var(--color-primary-dark) 0%, var(--color-bg) 32%, #ecfdf5 100%)',
-      paddingBottom: selectionComplete
-        ? 'calc(72px + env(safe-area-inset-bottom))'
-        : undefined,
-    }),
-    [selectionComplete],
-  )
+    theme,
+    setTheme,
+    results,
+    isLoading,
+    error,
+    loadMore,
+    hasMore,
+    handleQueryChange,
+    handleHistorySearch,
+    handleSelect,
+    handleThemeHistorySelect,
+    handleBeforeCreate,
+    handleCompleteChange,
+    mainStyle,
+  } = useSearchPage()
 
   return (
     <div className="min-h-screen" style={mainStyle}>


### PR DESCRIPTION
## 概要
SearchPageの状態管理ロジックをカスタムフックに抽出。

## 変更内容
- useSearchPage カスタムフックを作成
- SearchPage.tsx をプレゼンテーション層に集中させる
- 全ての状態管理、イベントハンドラ、メモ化をフックに移動
- 外部APIは変更なし、既存テストは全パス

Closes #72