### PR TITLE
feat: 映画検索結果カードのsubtitleを公開年から監督名に変更

### DIFF
--- a/src/services/tmdb.test.ts
+++ b/src/services/tmdb.test.ts
@@ -43,7 +43,7 @@ describe('searchMovies', () => {
     })
   })
 
-  it('maps TMDb response correctly', async () => {
+  it('maps TMDb response correctly with director name', async () => {
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
         HttpResponse.json({
@@ -53,6 +53,9 @@ describe('searchMovies', () => {
           total_results: 1,
         }),
       ),
+      http.get(`${BASE_URL}/movie/:id`, () =>
+        HttpResponse.json(mockMovieDetail()),
+      ),
     )
     const result = await searchMovies('key', 'test')
     expect(result.ok).toBe(true)
@@ -61,11 +64,11 @@ describe('searchMovies', () => {
       expect(result.data.items[0].category).toBe('movie')
       expect(result.data.items[0].title).toBe('Test Movie')
       expect(result.data.items[0].thumbnailUrl).toContain('/poster.jpg')
-      expect(result.data.items[0].subtitle).toBe('2024')
+      expect(result.data.items[0].subtitle).toBe('Test Director')
     }
   })
 
-  it('shows 公開日不明 when release_date is missing', async () => {
+  it('shows 監督不明 when credits fetch fails', async () => {
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
         HttpResponse.json({
@@ -75,27 +78,31 @@ describe('searchMovies', () => {
           total_results: 1,
         }),
       ),
+      http.get(`${BASE_URL}/movie/:id`, () => HttpResponse.error()),
     )
     const result = await searchMovies('key', 'test')
     if (result.ok) {
-      expect(result.data.items[0].subtitle).toBe('公開日不明')
+      expect(result.data.items[0].subtitle).toBe('監督不明')
     }
   })
 
-  it('shows 公開日不明 when release_date is empty string', async () => {
+  it('shows 監督不明 when no Director in crew', async () => {
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
         HttpResponse.json({
           page: 1,
-          results: [mockMovie({ release_date: '' })],
+          results: [mockMovie()],
           total_pages: 1,
           total_results: 1,
         }),
       ),
+      http.get(`${BASE_URL}/movie/:id`, () =>
+        HttpResponse.json(mockMovieDetail({ credits: { crew: [] } })),
+      ),
     )
     const result = await searchMovies('key', 'test')
     if (result.ok) {
-      expect(result.data.items[0].subtitle).toBe('公開日不明')
+      expect(result.data.items[0].subtitle).toBe('監督不明')
     }
   })
 
@@ -109,10 +116,59 @@ describe('searchMovies', () => {
           total_results: 1,
         }),
       ),
+      http.get(`${BASE_URL}/movie/:id`, () =>
+        HttpResponse.json(mockMovieDetail()),
+      ),
     )
     const result = await searchMovies('key', 'test')
     if (result.ok) {
       expect(result.data.items[0].thumbnailUrl).toBe('')
+    }
+  })
+
+  it('fetches director info for multiple movies in parallel', async () => {
+    const movies = [
+      mockMovie({ id: 1, title: 'Movie A' }),
+      mockMovie({ id: 2, title: 'Movie B' }),
+    ]
+    server.use(
+      http.get(`${BASE_URL}/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: movies,
+          total_pages: 1,
+          total_results: 2,
+        }),
+      ),
+      http.get(`${BASE_URL}/movie/1`, () =>
+        HttpResponse.json(
+          mockMovieDetail({
+            id: 1,
+            title: 'Movie A',
+            credits: {
+              crew: [{ id: 10, name: 'Director A', job: 'Director' }],
+            },
+          }),
+        ),
+      ),
+      http.get(`${BASE_URL}/movie/2`, () =>
+        HttpResponse.json(
+          mockMovieDetail({
+            id: 2,
+            title: 'Movie B',
+            credits: {
+              crew: [{ id: 20, name: 'Director B', job: 'Director' }],
+            },
+          }),
+        ),
+      ),
+    )
+    const result = await searchMovies('key', 'test')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.items).toHaveLength(2)
+      expect(result.data.items[0].subtitle).toBe('Director A')
+      expect(result.data.items[1].subtitle).toBe('Director B')
     }
   })
 })

--- a/src/services/tmdb.ts
+++ b/src/services/tmdb.ts
@@ -121,7 +121,11 @@ export async function searchMovies(
 
   const { total_results, results } = result.data
   const sliced = sliceResultsForOffset(results, startIndex, maxResults)
-  const mapped = sliced.map(mapMovieToSearchResult)
+
+  const directorNames = await fetchDirectorNames(apiKey, sliced, signal)
+  const mapped = sliced.map((movie, i) =>
+    mapMovieToSearchResult(movie, directorNames[i]),
+  )
 
   return {
     ok: true,
@@ -161,15 +165,52 @@ export async function getMovieById(
   return { ok: true, data: mapMovieDetailToSearchResult(result.data) }
 }
 
+// ── Director fetching ───────────────────────────────────────────────
+
+async function fetchDirectorName(
+  apiKey: string,
+  movieId: number,
+  signal?: AbortSignal,
+): Promise<string | undefined> {
+  const params = new URLSearchParams({
+    api_key: apiKey,
+    language: 'ja-JP',
+    append_to_response: 'credits',
+  })
+
+  const result = await fetchJson<TMDbMovieDetail>(
+    `${BASE_URL}/movie/${movieId}?${params.toString()}`,
+    { signal, validate: validateMovieDetail },
+  )
+
+  if (!result.ok) return undefined
+
+  const director = result.data.credits?.crew.find((c) => c.job === 'Director')
+  return director?.name
+}
+
+async function fetchDirectorNames(
+  apiKey: string,
+  movies: TMDbMovie[],
+  signal?: AbortSignal,
+): Promise<(string | undefined)[]> {
+  const results = await Promise.allSettled(
+    movies.map((movie) => fetchDirectorName(apiKey, movie.id, signal)),
+  )
+  return results.map((r) => (r.status === 'fulfilled' ? r.value : undefined))
+}
+
 // ── Mapping ─────────────────────────────────────────────────────────
 
-function mapMovieToSearchResult(movie: TMDbMovie): SearchResultItem {
-  const releaseYear = movie.release_date?.split('-')[0]
+function mapMovieToSearchResult(
+  movie: TMDbMovie,
+  directorName?: string,
+): SearchResultItem {
   return {
     id: String(movie.id),
     category: 'movie',
     title: movie.title || 'タイトル不明',
-    subtitle: releaseYear || '公開日不明',
+    subtitle: directorName ?? '監督不明',
     thumbnailUrl: movie.poster_path
       ? `${IMAGE_BASE_URL}${movie.poster_path}`
       : '',


### PR DESCRIPTION
## 概要

映画検索結果カードの subtitle を公開年から監督名に変更する。

## 変更内容

- `searchMovies()` で検索結果取得後、各映画の詳細API (`/movie/{id}?append_to_response=credits`) に並列リクエストして監督名を取得
- `mapMovieToSearchResult()` に `directorName` パラメータを追加し、subtitle に設定
- `Promise.allSettled()` を使用して個別のリクエスト失敗が他に影響しないよう設計
- credits 取得失敗時やDirectorが存在しない場合は「監督不明」にフォールバック

## テスト

- 監督名が正しく表示されるテスト
- credits取得失敗時のフォールバックテスト  
- Director不在時のフォールバックテスト
- 複数映画の並列取得テスト

closes #96