### PR TITLE
feat: systemdサービスを導入してサーバーを永続化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,48 @@ export default defineConfig([
   },
 ])
 ```
+
+## 本番デプロイ (Production Deployment)
+
+### systemd サービスとして実行
+
+このアプリケーションを systemd サービスとして永続化できます。
+
+#### 前提条件
+
+- Node.js がインストールされていること
+- `npm install` で依存パッケージがインストール済みであること
+- `.env` ファイルに API キーが設定されていること
+
+#### セットアップ手順
+
+1. セットアップスクリプトを実行します:
+
+```bash
+sudo ./scripts/setup-service.sh
+```
+
+これにより以下が行われます:
+
+- `my-top3.service` を `/etc/systemd/system/` にコピー
+- systemd デーモンをリロード
+- サービスを有効化（OS 起動時に自動起動）
+- サービスを起動
+
+#### サービス管理コマンド
+
+```bash
+# ステータス確認
+sudo systemctl status my-top3
+
+# 停止
+sudo systemctl stop my-top3
+
+# 再起動
+sudo systemctl restart my-top3
+
+# ログ確認
+sudo journalctl -u my-top3 -f
+```
+
+サーバーはデフォルトで `http://localhost:8000` で起動します。

--- a/my-top3.service
+++ b/my-top3.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=My Top3 Application
+After=network.target
+
+[Service]
+Type=simple
+User=exedev
+WorkingDirectory=/home/exedev/my-top3
+EnvironmentFile=/home/exedev/my-top3/.env
+ExecStartPre=/usr/bin/npm run build
+ExecStart=/usr/bin/node --import tsx/esm src/server/prod.ts
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+Environment=PORT=8000
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup-service.sh
+++ b/scripts/setup-service.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# setup-service.sh - my-top3 systemd サービスのセットアップスクリプト
+# root 権限が必要です: sudo ./scripts/setup-service.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+SERVICE_FILE="$PROJECT_DIR/my-top3.service"
+SERVICE_NAME="my-top3.service"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "エラー: このスクリプトは root 権限で実行してください" >&2
+  echo "使い方: sudo $0" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SERVICE_FILE" ]]; then
+  echo "エラー: サービスファイルが見つかりません: $SERVICE_FILE" >&2
+  exit 1
+fi
+
+echo "==> サービスファイルをコピーしています..."
+cp "$SERVICE_FILE" /etc/systemd/system/"$SERVICE_NAME"
+
+echo "==> systemd デーモンをリロードしています..."
+systemctl daemon-reload
+
+echo "==> サービスを有効化しています..."
+systemctl enable "$SERVICE_NAME"
+
+echo "==> サービスを起動しています..."
+systemctl start "$SERVICE_NAME"
+
+echo "==> 完了！ステータスを確認します:"
+systemctl status "$SERVICE_NAME" --no-pager


### PR DESCRIPTION
Closes #94

## 変更内容

- `my-top3.service` systemd ユニットファイルを追加
  - `ExecStart` は `npm start` と同等の `node --import tsx/esm src/server/prod.ts`
  - `ExecStartPre` でビルドを実行
  - `EnvironmentFile` で `.env` を読み込み
  - 障害時に自動再起動（5秒間隔）
  - OS起動時に自動起動
- `scripts/setup-service.sh` セットアップスクリプトを追加
  - root権限チェック付き
  - サービスファイルのコピー、daemon-reload、enable、start を一括実行
- README に本番デプロイ手順を追記