### PR TITLE
feat: PC表示時のレイアウト幅を改善

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -62,7 +62,7 @@ export default function SearchResults({
   }
 
   return (
-    <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {results.map((item) => (
         <ResultCard key={item.id} item={item} onSelect={onSelect} />
       ))}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -50,17 +50,19 @@ function SearchPage() {
         </p>
       </div>
 
-      <div className="mx-auto max-w-3xl px-3 sm:px-4">
+      <div className="mx-auto max-w-5xl px-3 sm:px-4">
         {/* Theme Input Section */}
-        <div
-          className="rounded-xl p-4 shadow-sm sm:p-5"
-          style={{
-            backgroundColor: 'var(--color-surface)',
-            border: '1px solid var(--color-border)',
-          }}
-        >
-          <ThemeInput value={theme} onChange={setTheme} />
-          <ThemeHistory onSelect={handleThemeHistorySelect} />
+        <div className="mx-auto max-w-2xl">
+          <div
+            className="rounded-xl p-4 shadow-sm sm:p-5"
+            style={{
+              backgroundColor: 'var(--color-surface)',
+              border: '1px solid var(--color-border)',
+            }}
+          >
+            <ThemeInput value={theme} onChange={setTheme} />
+            <ThemeHistory onSelect={handleThemeHistorySelect} />
+          </div>
         </div>
 
         {/* Selection Area - Sticky */}

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -31,7 +31,7 @@ function Top3Page() {
             'linear-gradient(180deg, var(--color-bg) 0%, #ecfdf5 100%)',
         }}
       >
-        <div className="mx-auto max-w-3xl px-3 py-4 text-center sm:px-4 sm:py-6 lg:py-8">
+        <div className="mx-auto max-w-4xl px-3 py-4 text-center sm:px-4 sm:py-6 lg:py-8">
           <ErrorMessage message="作品が選択されていません。トップページから3作品を選んでください。">
             <Button component={Link} to="/" variant="outlined" size="small">
               Top3を作成する
@@ -50,7 +50,7 @@ function Top3Page() {
           'linear-gradient(180deg, var(--color-bg) 0%, #f0fdf4 50%, #ecfdf5 100%)',
       }}
     >
-      <div className="mx-auto max-w-3xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
+      <div className="mx-auto max-w-4xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
         {/* Header with decorative line */}
         <div className="text-center">
           <div


### PR DESCRIPTION
Closes #98

## 変更内容
- **SearchPage**: コンテナ幅を `max-w-3xl` → `max-w-5xl` に拡大、テーマ入力セクションは `max-w-2xl mx-auto` で中央配置を維持
- **Top3Page**: コンテナ幅を `max-w-3xl` → `max-w-4xl` に拡大
- **SearchResults**: `lg:grid-cols-3` を追加し、大画面で3カラムグリッド表示に対応