### PR TITLE
feat: 各セクションの幅・余白を統一

### DIFF
--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -23,7 +23,7 @@ type TabSwitcherProps = {
 
 export default function TabSwitcher({ value, onChange }: TabSwitcherProps) {
   return (
-    <div className="mt-6">
+    <div className="mt-0">
       <Tabs
         value={value}
         onChange={(_, newValue: MediaCategory) => onChange(newValue)}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -67,12 +67,11 @@ function SearchPage() {
 
         {/* Selection Area - Sticky */}
         <div
-          className="sticky z-30 -mx-3 mt-5 px-3 pb-3 pt-2 sm:-mx-4 sm:px-4"
+          className="sticky z-30 mt-4 rounded-xl p-4 shadow-md sm:p-5"
           style={{
             top: 0,
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            backgroundColor: 'rgba(255,255,255,0.75)',
+            backgroundColor: 'var(--color-surface)',
+            border: '1px solid var(--color-border)',
           }}
         >
           <SelectionArea


### PR DESCRIPTION
Closes #99

## 変更内容
- Selection Area のスタイルを他セクションと同じカード形式に統一 (rounded-xl, p-4 sm:p-5, border, surface bg, shadow-md)
- 負のマージン (-mx-3) と backdrop blur を削除
- セクション間の余白を mt-4 に統一
- TabSwitcher の mt-6 を mt-0 に変更（親で余白制御）