### PR TITLE
feat: ビジュアルデザインの洗練（フォント・カラー・質感）

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Outfit:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <title>My No.1s</title>

--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -10,6 +10,12 @@ import { buildTop3Url } from '../utils/url-params'
 import type { MediaCategory, SearchResultItem } from '../types/common'
 import { CATEGORY_LABELS_EN } from '../constants/category'
 
+const CATEGORY_ICONS: Record<MediaCategory, string> = {
+  book: '📖',
+  music: '🎵',
+  movie: '🎬',
+}
+
 type SelectionAreaProps = {
   theme: string
   onBeforeCreate?: () => void
@@ -28,12 +34,17 @@ function SlotCard({
   if (!item) {
     return (
       <div
-        className="flex h-20 flex-1 flex-col items-center justify-center rounded-xl border-2 border-dashed p-2 transition-colors sm:h-28"
+        className="gradient-border-slot flex h-20 flex-1 flex-col items-center justify-center rounded-xl p-2 transition-all sm:h-28"
         style={{
-          borderColor: 'var(--color-border)',
           backgroundColor: 'var(--color-surface)',
         }}
       >
+        <span
+          className="pointer-events-none select-none text-2xl opacity-15 sm:text-3xl"
+          aria-hidden="true"
+        >
+          {CATEGORY_ICONS[category]}
+        </span>
         <Typography
           variant="caption"
           sx={{ fontSize: '0.75rem', fontWeight: 600 }}
@@ -53,9 +64,9 @@ function SlotCard({
 
   return (
     <div
-      className="relative flex h-20 flex-1 items-center gap-2 rounded-xl border-2 p-2 transition-colors sm:h-28"
+      className="slot-selected relative flex h-20 flex-1 items-center gap-2 rounded-xl border-2 p-2 transition-all sm:h-28"
       style={{
-        borderColor: 'var(--color-border)',
+        borderColor: 'var(--color-primary-light)',
         backgroundColor: 'var(--color-surface)',
       }}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -25,8 +25,12 @@
   --color-border: #e2e8f0;
 
   /* Fonts */
-  --font-display: 'Outfit', 'Noto Sans JP', sans-serif;
-  --font-body: 'Noto Sans JP', 'Outfit', sans-serif;
+  --font-display: 'Sora', 'Outfit', 'Noto Sans JP', sans-serif;
+  --font-body: 'Noto Sans JP', 'Sora', sans-serif;
+
+  /* Colored Shadows */
+  --shadow-primary: 0 4px 14px rgba(13, 148, 136, 0.15);
+  --shadow-card: 0 1px 3px rgb(0 0 0 / 0.06), 0 4px 12px rgb(0 0 0 / 0.04);
 }
 
 /* Base styles */
@@ -34,6 +38,58 @@ body {
   font-family: var(--font-body);
   color: var(--color-text-primary);
   background-color: var(--color-bg);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.03'/%3E%3C/svg%3E");
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Glass Card utility */
+.glass-card {
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: var(--shadow-card);
+}
+
+/* Gradient text utility */
+.gradient-text {
+  background: linear-gradient(135deg, #0d9488 0%, #059669 50%, #14b8a6 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Gradient border for slots */
+.gradient-border-slot {
+  position: relative;
+  border: none !important;
+  background: var(--color-surface);
+}
+.gradient-border-slot::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: linear-gradient(
+    135deg,
+    var(--color-border) 0%,
+    var(--color-primary-light) 50%,
+    var(--color-border) 100%
+  );
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  pointer-events: none;
+}
+
+/* Selected slot glow */
+.slot-selected {
+  box-shadow: var(--shadow-primary);
+  border-color: var(--color-primary-light) !important;
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -32,9 +32,30 @@ function SearchPage() {
   return (
     <div className="min-h-screen" style={mainStyle}>
       {/* Hero Section */}
-      <div className="px-3 pb-6 pt-8 text-center sm:px-4 sm:pb-8 sm:pt-12">
+      <div className="relative overflow-hidden px-3 pb-6 pt-8 text-center sm:px-4 sm:pb-8 sm:pt-12">
+        {/* Decorative dots pattern */}
+        <svg
+          className="pointer-events-none absolute left-1/2 top-0 -translate-x-1/2 opacity-10"
+          width="320"
+          height="120"
+          viewBox="0 0 320 120"
+          fill="none"
+          aria-hidden="true"
+        >
+          {[0, 1, 2, 3, 4, 5, 6, 7].map((col) =>
+            [0, 1, 2].map((row) => (
+              <circle
+                key={`${col}-${row}`}
+                cx={40 * col + 20}
+                cy={40 * row + 20}
+                r="4"
+                fill="white"
+              />
+            )),
+          )}
+        </svg>
         <h1
-          className="text-3xl font-extrabold tracking-tight sm:text-4xl"
+          className="relative text-3xl font-extrabold tracking-tight sm:text-4xl"
           style={{
             fontFamily: 'var(--font-display)',
             color: '#fff',
@@ -43,8 +64,8 @@ function SearchPage() {
           My No.1s
         </h1>
         <p
-          className="mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"
-          style={{ color: 'rgba(255,255,255,0.8)' }}
+          className="relative mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"
+          style={{ color: 'rgba(255,255,255,0.9)' }}
         >
           テーマを決めて、お気に入りの3作品を選ぼう
         </p>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,13 @@
 import { createTheme } from '@mui/material/styles'
 
-const fontFamily = ['"Noto Sans JP"', '"Outfit"', 'sans-serif'].join(',')
+const fontFamily = ['"Noto Sans JP"', '"Sora"', 'sans-serif'].join(',')
 
-const displayFontFamily = ['"Outfit"', '"Noto Sans JP"', 'sans-serif'].join(',')
+const displayFontFamily = [
+  '"Sora"',
+  '"Outfit"',
+  '"Noto Sans JP"',
+  'sans-serif',
+].join(',')
 
 const theme = createTheme({
   palette: {
@@ -47,20 +52,29 @@ const theme = createTheme({
     },
   },
   shape: {
-    borderRadius: 10,
+    borderRadius: 12,
   },
   components: {
     MuiButton: {
       styleOverrides: {
         root: {
-          borderRadius: 20,
+          borderRadius: 24,
           textTransform: 'none' as const,
           fontWeight: 600,
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            transform: 'scale(1.03)',
+          },
+          '&:active': {
+            transform: 'scale(0.98)',
+          },
         },
         containedPrimary: {
           background: 'linear-gradient(135deg, #0d9488 0%, #14b8a6 100%)',
+          boxShadow: '0 4px 14px rgba(13, 148, 136, 0.25)',
           '&:hover': {
             background: 'linear-gradient(135deg, #0f766e 0%, #0d9488 100%)',
+            boxShadow: '0 6px 20px rgba(13, 148, 136, 0.35)',
           },
         },
       },
@@ -68,9 +82,10 @@ const theme = createTheme({
     MuiCard: {
       styleOverrides: {
         root: {
-          borderRadius: 12,
+          borderRadius: 14,
           boxShadow:
-            '0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.08)',
+            '0 1px 3px 0 rgb(0 0 0 / 0.06), 0 4px 12px rgb(0 0 0 / 0.04)',
+          transition: 'box-shadow 0.2s ease, transform 0.2s ease',
         },
       },
     },


### PR DESCRIPTION
Closes #100

## 変更内容

### フォント
- **Sora** をディスプレイフォントとして追加（モダンな幾何学的サンセリフ）
- Google Fonts リンクに Sora を追加
- CSS変数・MUIテーマの displayFontFamily を更新

### カラー＆テクスチャ
- body に微細なノイズテクスチャを追加
- `.glass-card` ユーティリティクラス（glassmorphism）
- `.gradient-text` ユーティリティクラス（teal→emerald）
- カラーシャドウCSS変数: `--shadow-primary`, `--shadow-card`

### ヒーローセクション
- 装飾的なSVGドットパターンを背景に追加
- サブタイトルのコントラストを改善（0.8→0.9）

### セレクションスロット
- 空スロット: ダッシュボーダー → グラデーションボーダーに変更
- カテゴリアイコン（📖🎵🎬）をウォーターマークとして表示
- 選択済みスロット: ティールグロー+シャドウで視覚的に区別

### ボタン
- ボーダー半径を拡大（20px→24px）
- ホバー時にscale(1.03)、アクティブ時にscale(0.98)
- containedPrimary にカラーシャドウ追加

### カード
- シャドウを改善（よりソフトに）
- ボーダー半径を拡大（12px→14px）
- hover/transform トランジション追加