### PR TITLE
feat: 検索結果カードのデザイン改善

### DIFF
--- a/src/components/ResultCard.test.tsx
+++ b/src/components/ResultCard.test.tsx
@@ -34,6 +34,17 @@ describe('ResultCard', () => {
     expect(onSelect).toHaveBeenCalledWith(item)
   })
 
+  it('calls onSelect when card is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const item = createSearchResultItem()
+    render(<ResultCard item={item} onSelect={onSelect} />)
+    await user.click(
+      screen.getByRole('button', { name: /My Book|Test Title/i }),
+    )
+    expect(onSelect).toHaveBeenCalled()
+  })
+
   it('shows select button text', () => {
     render(<ResultCard item={createSearchResultItem()} onSelect={vi.fn()} />)
     expect(screen.getByText('#1に選ぶ')).toBeInTheDocument()

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -17,10 +17,13 @@ const NO_IMAGE_PLACEHOLDERS: Record<MediaCategory, string> = {
     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23ede9fe' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%237c3aed' font-family='sans-serif' font-size='32'%3E🎬%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%236d28d9' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
 }
 
-const CATEGORY_ACCENT: Record<MediaCategory, string> = {
-  book: '#d97706',
-  music: '#2563eb',
-  movie: '#7c3aed',
+const THUMBNAIL_DIMENSIONS: Record<
+  MediaCategory,
+  { width: number; aspectRatio: string }
+> = {
+  book: { width: 80, aspectRatio: '2 / 3' },
+  music: { width: 100, aspectRatio: '1 / 1' },
+  movie: { width: 80, aspectRatio: '2 / 3' },
 }
 
 type ResultCardProps = {
@@ -31,26 +34,39 @@ type ResultCardProps = {
 export default function ResultCard({ item, onSelect }: ResultCardProps) {
   const { selection } = useSelection()
   const isSelected = selection[item.category]?.id === item.id
-  const accentColor = CATEGORY_ACCENT[item.category]
   const placeholder = NO_IMAGE_PLACEHOLDERS[item.category]
+  const dimensions = THUMBNAIL_DIMENSIONS[item.category]
+
+  const handleCardClick = () => {
+    if (!isSelected) {
+      onSelect(item)
+    }
+  }
 
   return (
     <Card
+      onClick={handleCardClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleCardClick()
+        }
+      }}
       sx={{
         display: 'flex',
-        borderLeft: `4px solid ${accentColor}`,
         transition: 'all 0.2s ease',
-        cursor: 'pointer',
+        cursor: isSelected ? 'default' : 'pointer',
         WebkitTapHighlightColor: 'transparent',
         ...(isSelected && {
-          bgcolor: 'action.selected',
-          borderLeftColor: 'success.main',
-          boxShadow: (theme) => `0 0 0 1px ${theme.palette.success.main}`,
+          border: (theme) => `2px solid ${theme.palette.primary.main}`,
+          opacity: 0.85,
         }),
         ...(!isSelected && {
           '&:hover': {
-            transform: 'translateY(-2px)',
-            boxShadow: 4,
+            transform: 'translateY(-2px) scale(1.02)',
+            boxShadow: 8,
           },
           '&:active': {
             transform: 'scale(0.98)',
@@ -58,21 +74,36 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
         }),
       }}
     >
-      <CardMedia
-        component="img"
-        sx={{
-          width: 100,
-          minHeight: 120,
-          objectFit: 'cover',
-          flexShrink: 0,
-        }}
-        image={item.thumbnailUrl || placeholder}
-        alt={item.title}
-        onError={(e) => {
-          const target = e.target as HTMLImageElement
-          target.src = placeholder
-        }}
-      />
+      <Box sx={{ position: 'relative', flexShrink: 0 }}>
+        <CardMedia
+          component="img"
+          sx={{
+            width: dimensions.width,
+            aspectRatio: dimensions.aspectRatio,
+            objectFit: 'cover',
+          }}
+          image={item.thumbnailUrl || placeholder}
+          alt={item.title}
+          onError={(e) => {
+            const target = e.target as HTMLImageElement
+            target.src = placeholder
+          }}
+        />
+        {isSelected && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: 'rgba(0, 0, 0, 0.4)',
+            }}
+          >
+            <CheckCircleIcon sx={{ color: 'white', fontSize: 32 }} />
+          </Box>
+        )}
+      </Box>
       <Box
         sx={{
           display: 'flex',
@@ -132,7 +163,10 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
               color="primary"
               disableElevation
               startIcon={<AddCircleOutlineIcon />}
-              onClick={() => onSelect(item)}
+              onClick={(e) => {
+                e.stopPropagation()
+                onSelect(item)
+              }}
               sx={{ mt: 1, fontSize: '0.8rem', minHeight: 36 }}
             >
               #1に選ぶ


### PR DESCRIPTION
Closes #102

## 変更内容

### ResultCard.tsx
- **左ボーダー削除**:  を削除（カテゴリはタブで既に表示済み）
- **カード全体クリック可能**: Card に `onClick`/`onKeyDown` を追加し、`role="button"` と `tabIndex={0}` でアクセシビリティ対応。ボタンの `onClick` には `stopPropagation` を追加して二重発火防止
- **カテゴリ別サムネイルサイズ**: `THUMBNAIL_DIMENSIONS` 定数で管理
  - book: width 80px, aspect-ratio 2:3
  - music: width 100px, aspect-ratio 1:1
  - movie: width 80px, aspect-ratio 2:3
- **選択状態の改善**:
  - 画像上にチェックマークオーバーレイ（半透明黒背景+白アイコン）
  - primary色の2pxボーダー
  - opacity 0.85 で視覚的区別
- **ホバーエフェクト強化**: `boxShadow: 8` + `scale(1.02)`

### ResultCard.test.tsx
- カードクリックでの `onSelect` 呼び出しテストを追加