### PR TITLE
feat: アニメーションとマイクロインタラクションの追加

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -63,8 +63,14 @@ export default function SearchResults({
 
   return (
     <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {results.map((item) => (
-        <ResultCard key={item.id} item={item} onSelect={onSelect} />
+      {results.map((item, index) => (
+        <div
+          key={item.id}
+          className="animate-fade-in-up"
+          style={index < 8 ? { animationDelay: `${index * 50}ms` } : undefined}
+        >
+          <ResultCard item={item} onSelect={onSelect} />
+        </div>
       ))}
 
       {isLoading && results.length === 0

--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -64,7 +64,7 @@ function SlotCard({
 
   return (
     <div
-      className="slot-selected relative flex h-20 flex-1 items-center gap-2 rounded-xl border-2 p-2 transition-all sm:h-28"
+      className="animate-scale-in slot-selected relative flex h-20 flex-1 items-center gap-2 rounded-xl border-2 p-2 transition-all sm:h-28"
       style={{
         borderColor: 'var(--color-primary-light)',
         backgroundColor: 'var(--color-surface)',

--- a/src/index.css
+++ b/src/index.css
@@ -93,3 +93,85 @@ body {
   box-shadow: var(--shadow-primary);
   border-color: var(--color-primary-light) !important;
 }
+
+/* Animations */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes pulse-soft {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.5s ease-out both;
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.4s ease-out both;
+}
+
+.animate-scale-in {
+  animation: scaleIn 0.3s ease-out both;
+}
+
+.animate-pulse-soft {
+  animation: pulse-soft 0.4s ease-in-out;
+}
+
+/* Staggered animation delays */
+.animate-delay-100 {
+  animation-delay: 100ms;
+}
+.animate-delay-200 {
+  animation-delay: 200ms;
+}
+.animate-delay-300 {
+  animation-delay: 300ms;
+}
+.animate-delay-400 {
+  animation-delay: 400ms;
+}
+
+/* Respect reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up,
+  .animate-fade-in,
+  .animate-scale-in,
+  .animate-pulse-soft {
+    animation: none !important;
+  }
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -55,7 +55,7 @@ function SearchPage() {
           )}
         </svg>
         <h1
-          className="relative text-3xl font-extrabold tracking-tight sm:text-4xl"
+          className="animate-fade-in-up relative text-3xl font-extrabold tracking-tight sm:text-4xl"
           style={{
             fontFamily: 'var(--font-display)',
             color: '#fff',
@@ -64,7 +64,7 @@ function SearchPage() {
           My No.1s
         </h1>
         <p
-          className="relative mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"
+          className="animate-fade-in-up animate-delay-200 relative mx-auto mt-2 max-w-md text-sm sm:mt-3 sm:text-base"
           style={{ color: 'rgba(255,255,255,0.9)' }}
         >
           テーマを決めて、お気に入りの3作品を選ぼう

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -122,27 +122,33 @@ function Top3Page() {
         )}
 
         <div className="mt-4 flex flex-col items-stretch gap-4 sm:mt-6 sm:flex-row">
-          <WorkCard
-            work={book.data}
-            loading={book.loading}
-            error={book.error}
-            label="BOOK"
-            onRetry={book.error ? book.retry : undefined}
-          />
-          <WorkCard
-            work={music.data}
-            loading={music.loading}
-            error={music.error}
-            label="MUSIC"
-            onRetry={music.error ? music.retry : undefined}
-          />
-          <WorkCard
-            work={movie.data}
-            loading={movie.loading}
-            error={movie.error}
-            label="MOVIE"
-            onRetry={movie.error ? movie.retry : undefined}
-          />
+          <div className="animate-fade-in-up flex-1">
+            <WorkCard
+              work={book.data}
+              loading={book.loading}
+              error={book.error}
+              label="BOOK"
+              onRetry={book.error ? book.retry : undefined}
+            />
+          </div>
+          <div className="animate-fade-in-up animate-delay-100 flex-1">
+            <WorkCard
+              work={music.data}
+              loading={music.loading}
+              error={music.error}
+              label="MUSIC"
+              onRetry={music.error ? music.retry : undefined}
+            />
+          </div>
+          <div className="animate-fade-in-up animate-delay-200 flex-1">
+            <WorkCard
+              work={movie.data}
+              loading={movie.loading}
+              error={movie.error}
+              label="MOVIE"
+              onRetry={movie.error ? movie.retry : undefined}
+            />
+          </div>
         </div>
 
         {showImage && (


### PR DESCRIPTION
Closes #103

## 変更内容

### CSS Keyframe Animations (src/index.css)
- `fadeInUp`, `fadeIn`, `scaleIn`, `pulse-soft` keyframe定義
- ユーティリティクラス: `.animate-fade-in-up`, `.animate-fade-in`, `.animate-scale-in`, `.animate-pulse-soft`
- スタガードディレイ: `.animate-delay-100` ~ `.animate-delay-400`
- `prefers-reduced-motion: reduce` でアニメーション無効化

### Hero Section (SearchPage.tsx)
- h1タイトルに `animate-fade-in-up`
- サブタイトルに `animate-fade-in-up animate-delay-200`

### Search Results (SearchResults.tsx)
- 検索結果カードにスタガード `animate-fade-in-up` (最初の8件にディレイ)

### Selection Slots (SelectionArea.tsx)
- 空→選択済みスロットに `animate-scale-in`

### Top3 Page WorkCards (Top3Page.tsx)
- 3枚のWorkCardにスタガード `animate-fade-in-up`

### パフォーマンス
- CSS-onlyアプローチ (framer-motion不使用)
- transform/opacityのみ使用 (レイアウトスラッシング回避)
- `prefers-reduced-motion` 対応