### PR TITLE
feat: Amazonリンクにアフィリエイトタグを追加

### DIFF
--- a/src/services/google-books.test.ts
+++ b/src/services/google-books.test.ts
@@ -130,7 +130,7 @@ describe('searchBooks', () => {
     const result = await searchBooks('key', 'test')
     if (result.ok) {
       expect(result.data.items[0].externalUrl).toBe(
-        'https://www.amazon.co.jp/dp/1234567890',
+        'https://www.amazon.co.jp/dp/1234567890?tag=yuaioiaiu-22',
       )
     }
   })

--- a/src/services/google-books.ts
+++ b/src/services/google-books.ts
@@ -197,12 +197,12 @@ function buildExternalUrl(
 ): string {
   const isbn10 = identifiers?.find((id) => id.type === 'ISBN_10')
   if (isbn10) {
-    return `https://www.amazon.co.jp/dp/${isbn10.identifier}`
+    return `https://www.amazon.co.jp/dp/${isbn10.identifier}?tag=yuaioiaiu-22`
   }
 
   const isbn13 = identifiers?.find((id) => id.type === 'ISBN_13')
   if (isbn13) {
-    return `https://www.amazon.co.jp/dp/${isbn13.identifier}`
+    return `https://www.amazon.co.jp/dp/${isbn13.identifier}?tag=yuaioiaiu-22`
   }
 
   return `https://books.google.co.jp/books?id=${encodeURIComponent(volumeId)}`


### PR DESCRIPTION
## 変更内容

Amazonリンクにアフィリエイトタグ (`tag=yuaioiaiu-22`) を付与するようにしました。

### 変更ファイル
- `src/services/google-books.ts` — `buildExternalUrl` の Amazon URL に `?tag=yuaioiaiu-22` を追加
- `src/services/google-books.test.ts` — テストの期待値を更新

### 生成URL例
```
https://www.amazon.co.jp/dp/{ISBN}?tag=yuaioiaiu-22
```