### PR TITLE
feat: 初回ユーザー向けオンボーディング (#119)

### DIFF
--- a/src/components/StepGuide.test.tsx
+++ b/src/components/StepGuide.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import StepGuide from './StepGuide'
+
+describe('StepGuide', () => {
+  it('renders 3 step labels', () => {
+    render(<StepGuide />)
+    expect(screen.getByText('検索する')).toBeInTheDocument()
+    expect(screen.getByText('3つ選ぶ')).toBeInTheDocument()
+    expect(screen.getByText('シェアする')).toBeInTheDocument()
+  })
+
+  it('renders step numbers', () => {
+    render(<StepGuide />)
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('has accessible region', () => {
+    render(<StepGuide />)
+    expect(
+      screen.getByRole('list', { name: '使い方ステップ' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/StepGuide.tsx
+++ b/src/components/StepGuide.tsx
@@ -1,0 +1,61 @@
+import SearchIcon from '@mui/icons-material/Search'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import ShareIcon from '@mui/icons-material/Share'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+
+const steps = [
+  { number: '1', label: '検索する', icon: SearchIcon },
+  { number: '2', label: '3つ選ぶ', icon: CheckCircleOutlineIcon },
+  { number: '3', label: 'シェアする', icon: ShareIcon },
+] as const
+
+export default function StepGuide() {
+  return (
+    <ol
+      aria-label="使い方ステップ"
+      className="flex items-center justify-center gap-2 sm:gap-4"
+    >
+      {steps.map((step, i) => {
+        const Icon = step.icon
+        return (
+          <li key={step.number} className="flex items-center gap-2 sm:gap-4">
+            <div className="flex flex-col items-center gap-1">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-full sm:h-12 sm:w-12"
+                style={{
+                  backgroundColor: 'rgba(255,255,255,0.2)',
+                }}
+              >
+                <Icon
+                  sx={{ color: '#fff', fontSize: { xs: 20, sm: 24 } }}
+                  aria-hidden
+                />
+              </div>
+              <span
+                className="text-xs font-bold sm:text-sm"
+                style={{ color: '#fff' }}
+              >
+                {step.number}
+              </span>
+              <span
+                className="text-xs sm:text-sm"
+                style={{ color: 'rgba(255,255,255,0.9)' }}
+              >
+                {step.label}
+              </span>
+            </div>
+            {i < steps.length - 1 && (
+              <ArrowForwardIcon
+                sx={{
+                  color: 'rgba(255,255,255,0.6)',
+                  fontSize: { xs: 16, sm: 20 },
+                }}
+                aria-hidden
+              />
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/src/components/ThemeInput.test.tsx
+++ b/src/components/ThemeInput.test.tsx
@@ -31,3 +31,37 @@ describe('ThemeInput', () => {
     ).toBeInTheDocument()
   })
 })
+
+it('renders suggestion chips', () => {
+  render(<ThemeInput value="" onChange={vi.fn()} />)
+  expect(screen.getByText('夏に読みたい')).toBeInTheDocument()
+  expect(screen.getByText('青春')).toBeInTheDocument()
+  expect(screen.getByText('2024年ベスト')).toBeInTheDocument()
+})
+
+it('calls onChange when a suggestion chip is clicked', async () => {
+  const user = userEvent.setup()
+  const onChange = vi.fn()
+  render(<ThemeInput value="" onChange={onChange} />)
+  await user.click(screen.getByText('青春'))
+  expect(onChange).toHaveBeenCalledWith('青春')
+})
+
+it('hides suggestion chips when value is non-empty', () => {
+  render(<ThemeInput value="何か" onChange={vi.fn()} />)
+  expect(screen.queryByText('夏に読みたい')).not.toBeInTheDocument()
+})
+
+it('shows guide text when value is empty', () => {
+  render(<ThemeInput value="" onChange={vi.fn()} />)
+  expect(
+    screen.getByText('テーマは後からでもOK！まず好きな作品を検索しよう'),
+  ).toBeInTheDocument()
+})
+
+it('hides guide text when value is non-empty', () => {
+  render(<ThemeInput value="何か" onChange={vi.fn()} />)
+  expect(
+    screen.queryByText('テーマは後からでもOK！まず好きな作品を検索しよう'),
+  ).not.toBeInTheDocument()
+})

--- a/src/components/ThemeInput.tsx
+++ b/src/components/ThemeInput.tsx
@@ -1,5 +1,8 @@
 import TextField from '@mui/material/TextField'
+import Chip from '@mui/material/Chip'
 import { MAX_THEME_LENGTH } from '../hooks/useTheme'
+
+const THEME_SUGGESTIONS = ['夏に読みたい', '青春', '2024年ベスト'] as const
 
 type ThemeInputProps = {
   value: string
@@ -8,28 +11,53 @@ type ThemeInputProps = {
 
 function ThemeInput({ value, onChange }: ThemeInputProps) {
   const isOverLimit = value.length > MAX_THEME_LENGTH
+  const showSuggestions = value.length === 0
 
   return (
-    <TextField
-      fullWidth
-      label="テーマ"
-      placeholder="例: 雨の日に楽しむ3作品"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      helperText={
-        isOverLimit
-          ? `テーマは${MAX_THEME_LENGTH}文字以内で入力してください (${value.length} / ${MAX_THEME_LENGTH})`
-          : `${value.length} / ${MAX_THEME_LENGTH}`
-      }
-      error={isOverLimit}
-      variant="outlined"
-      size="small"
-      slotProps={{
-        htmlInput: {
-          maxLength: MAX_THEME_LENGTH + 10,
-        },
-      }}
-    />
+    <div>
+      <TextField
+        fullWidth
+        label="テーマ"
+        placeholder="例: 雨の日に楽しむ3作品"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        helperText={
+          isOverLimit
+            ? `テーマは${MAX_THEME_LENGTH}文字以内で入力してください (${value.length} / ${MAX_THEME_LENGTH})`
+            : `${value.length} / ${MAX_THEME_LENGTH}`
+        }
+        error={isOverLimit}
+        variant="outlined"
+        size="small"
+        slotProps={{
+          htmlInput: {
+            maxLength: MAX_THEME_LENGTH + 10,
+          },
+        }}
+      />
+      {showSuggestions && (
+        <>
+          <p
+            className="mt-2 text-xs"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            テーマは後からでもOK！まず好きな作品を検索しよう
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {THEME_SUGGESTIONS.map((suggestion) => (
+              <Chip
+                key={suggestion}
+                label={suggestion}
+                variant="outlined"
+                size="small"
+                clickable
+                onClick={() => onChange(suggestion)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,3 +1,4 @@
+import StepGuide from '../components/StepGuide'
 import TabSwitcher from '../components/TabSwitcher'
 import SearchBar from '../components/SearchBar'
 import SearchHistory from '../components/SearchHistory'
@@ -69,6 +70,9 @@ function SearchPage() {
         >
           テーマを決めて、お気に入りの3作品を選ぼう
         </p>
+        <div className="animate-fade-in-up animate-delay-400 relative mt-6">
+          <StepGuide />
+        </div>
       </div>
 
       <div className="mx-auto max-w-5xl px-3 sm:px-4">


### PR DESCRIPTION
## Summary

初回ユーザーがアプリの操作フローを理解できるよう、オンボーディングガイドを追加します。

## Changes

### 1. StepGuide コンポーネント (`src/components/StepGuide.tsx`)
- ヒーローセクション下部に3ステップフロー表示（検索する → 3つ選ぶ → シェアする）
- MUI アイコン（Search, CheckCircleOutline, Share）+ 矢印で視覚的にガイド
- アクセシブルな `<ol>` リスト構造

### 2. ThemeInput の改善 (`src/components/ThemeInput.tsx`)
- テーマ未入力時にサジェストチップ表示（夏に読みたい / 青春 / 2024年ベスト）
- ガイドテキスト:「テーマは後からでもOK！まず好きな作品を検索しよう」
- テーマ入力後はサジェスト・ガイドが非表示に

### 3. SearchPage 統合 (`src/pages/SearchPage.tsx`)
- ヒーローセクションに StepGuide を追加（アニメーション付き）

## Tests
- `StepGuide.test.tsx`: 3ステップ表示、番号、アクセシビリティ（3 tests）
- `ThemeInput.test.tsx`: サジェストチップ表示/クリック/非表示、ガイドテキスト表示/非表示（5 new tests）
- 全253テスト PASS ✅

Closes #119