### PR TITLE
feat: OGP/SEOメタタグの動的生成

### DIFF
--- a/src/server/ogp.test.ts
+++ b/src/server/ogp.test.ts
@@ -1,0 +1,359 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  escapeHtml,
+  buildOgTitle,
+  buildOgDescription,
+  buildMetaTags,
+  injectOgpTags,
+} from './ogp.ts'
+
+vi.mock('../services/google-books.ts', () => ({
+  getBookById: vi.fn(),
+}))
+vi.mock('../services/spotify.ts', () => ({
+  getAccessToken: vi.fn(),
+  getMusicById: vi.fn(),
+}))
+vi.mock('../services/tmdb.ts', () => ({
+  getMovieById: vi.fn(),
+}))
+
+const SAMPLE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>My No.1s</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`
+
+describe('escapeHtml', () => {
+  it('escapes HTML special characters', () => {
+    expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;',
+    )
+  })
+
+  it('escapes ampersands', () => {
+    expect(escapeHtml('A & B')).toBe('A &amp; B')
+  })
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#x27;s')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(escapeHtml('')).toBe('')
+  })
+})
+
+describe('buildOgTitle', () => {
+  it('includes theme name and site name', () => {
+    expect(buildOgTitle('夏の思い出')).toBe('夏の思い出 | My No.1s')
+  })
+
+  it('returns site name when theme is empty', () => {
+    expect(buildOgTitle('')).toBe('My No.1s')
+  })
+})
+
+describe('buildOgDescription', () => {
+  it('returns default description when no works', () => {
+    expect(buildOgDescription([])).toBe(
+      '本・音楽・映画からあなたのNo.1を選んで、みんなにシェアしよう！',
+    )
+  })
+
+  it('joins work titles with slash separator', () => {
+    const works = [
+      { title: '1Q84', category: '📚Book' },
+      { title: 'Bohemian Rhapsody', category: '🎵Music' },
+    ]
+    expect(buildOgDescription(works)).toBe(
+      '📚Book: 1Q84 / 🎵Music: Bohemian Rhapsody',
+    )
+  })
+
+  it('handles single work', () => {
+    const works = [{ title: 'Inception', category: '🎬Movie' }]
+    expect(buildOgDescription(works)).toBe('🎬Movie: Inception')
+  })
+
+  it('handles all three works', () => {
+    const works = [
+      { title: '1Q84', category: '📚Book' },
+      { title: 'Shape of You', category: '🎵Music' },
+      { title: 'Inception', category: '🎬Movie' },
+    ]
+    expect(buildOgDescription(works)).toBe(
+      '📚Book: 1Q84 / 🎵Music: Shape of You / 🎬Movie: Inception',
+    )
+  })
+})
+
+describe('buildMetaTags', () => {
+  it('generates all required OGP and Twitter meta tags', () => {
+    const result = buildMetaTags({
+      title: 'テスト | My No.1s',
+      description: '📚Book: 1Q84',
+      url: 'https://example.com/my-no1s?theme=test',
+    })
+
+    expect(result).toContain('og:title')
+    expect(result).toContain('og:description')
+    expect(result).toContain('og:type')
+    expect(result).toContain('og:url')
+    expect(result).toContain('og:site_name')
+    expect(result).toContain('twitter:card')
+    expect(result).toContain('twitter:title')
+    expect(result).toContain('twitter:description')
+  })
+
+  it('escapes HTML in values', () => {
+    const result = buildMetaTags({
+      title: '<script>alert(1)</script>',
+      description: 'test & "quoted"',
+      url: 'https://example.com',
+    })
+
+    expect(result).toContain('&lt;script&gt;')
+    expect(result).toContain('test &amp; &quot;quoted&quot;')
+  })
+
+  it('includes twitter:card as summary', () => {
+    const result = buildMetaTags({
+      title: 'Test',
+      description: 'Desc',
+      url: 'https://example.com',
+    })
+
+    expect(result).toContain('content="summary"')
+  })
+})
+
+describe('injectOgpTags', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    delete process.env['GOOGLE_BOOKS_API_KEY']
+    delete process.env['SPOTIFY_CLIENT_ID']
+    delete process.env['SPOTIFY_CLIENT_SECRET']
+    delete process.env['TMDB_API_KEY']
+  })
+
+  it('injects OGP meta tags before </head>', async () => {
+    const params = new URLSearchParams({ theme: '夏の思い出' })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s?theme=夏の思い出',
+      params,
+    )
+
+    expect(result).toContain('og:title')
+    expect(result).toContain('夏の思い出 | My No.1s')
+    expect(result).toContain('</head>')
+    // Meta tags should be before </head>
+    const ogIndex = result.indexOf('og:title')
+    const headCloseIndex = result.indexOf('</head>')
+    expect(ogIndex).toBeLessThan(headCloseIndex)
+  })
+
+  it('uses default title when no theme is provided', async () => {
+    const params = new URLSearchParams()
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    expect(result).toContain('content="My No.1s"')
+  })
+
+  it('truncates theme to 50 characters', async () => {
+    const longTheme = 'あ'.repeat(60)
+    const params = new URLSearchParams({ theme: longTheme })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    const truncated = 'あ'.repeat(50)
+    expect(result).toContain(`${truncated} | My No.1s`)
+  })
+
+  it('fetches book title and includes it in description', async () => {
+    process.env['GOOGLE_BOOKS_API_KEY'] = 'test-key'
+
+    const { getBookById } = await import('../services/google-books.ts')
+    vi.mocked(getBookById).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'book1',
+        category: 'book',
+        title: '1Q84',
+        subtitle: '村上春樹',
+        thumbnailUrl: '',
+        externalUrl: '',
+      },
+    })
+
+    const params = new URLSearchParams({
+      theme: 'おすすめ',
+      book: 'book1',
+    })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s?theme=おすすめ&book=book1',
+      params,
+    )
+
+    expect(result).toContain('📚Book: 1Q84')
+    expect(getBookById).toHaveBeenCalledWith('test-key', 'book1')
+  })
+
+  it('fetches all three works and includes them in description', async () => {
+    process.env['GOOGLE_BOOKS_API_KEY'] = 'test-key'
+    process.env['SPOTIFY_CLIENT_ID'] = 'sp-id'
+    process.env['SPOTIFY_CLIENT_SECRET'] = 'sp-secret'
+    process.env['TMDB_API_KEY'] = 'tmdb-key'
+
+    const { getBookById } = await import('../services/google-books.ts')
+    const { getAccessToken, getMusicById } =
+      await import('../services/spotify.ts')
+    const { getMovieById } = await import('../services/tmdb.ts')
+
+    vi.mocked(getBookById).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'book1',
+        category: 'book',
+        title: '1Q84',
+        subtitle: '村上春樹',
+        thumbnailUrl: '',
+        externalUrl: '',
+      },
+    })
+    vi.mocked(getAccessToken).mockResolvedValue({
+      ok: true,
+      data: 'mock-token',
+    })
+    vi.mocked(getMusicById).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'music1',
+        category: 'music',
+        title: 'Shape of You',
+        subtitle: 'Ed Sheeran',
+        thumbnailUrl: '',
+        externalUrl: '',
+      },
+    })
+    vi.mocked(getMovieById).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'movie1',
+        category: 'movie',
+        title: 'Inception',
+        subtitle: 'Christopher Nolan',
+        thumbnailUrl: '',
+        externalUrl: '',
+      },
+    })
+
+    const params = new URLSearchParams({
+      theme: '好きな作品',
+      book: 'book1',
+      music: 'music1',
+      movie: 'movie1',
+    })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    expect(result).toContain('📚Book: 1Q84')
+    expect(result).toContain('🎵Music: Shape of You')
+    expect(result).toContain('🎬Movie: Inception')
+  })
+
+  it('gracefully handles API errors', async () => {
+    process.env['GOOGLE_BOOKS_API_KEY'] = 'test-key'
+
+    const { getBookById } = await import('../services/google-books.ts')
+    vi.mocked(getBookById).mockResolvedValue({
+      ok: false,
+      error: { kind: 'server-error', message: 'API error' },
+    })
+
+    const params = new URLSearchParams({
+      theme: 'テスト',
+      book: 'invalid-id',
+    })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    // Should still inject OGP tags, just with default description
+    expect(result).toContain('og:title')
+    expect(result).toContain('テスト | My No.1s')
+    expect(result).toContain(
+      '本・音楽・映画からあなたのNo.1を選んで、みんなにシェアしよう！',
+    )
+  })
+
+  it('skips fetching when API keys are not set', async () => {
+    // No env vars set
+    const { getBookById } = await import('../services/google-books.ts')
+
+    const params = new URLSearchParams({
+      theme: 'テスト',
+      book: 'book1',
+    })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    expect(getBookById).not.toHaveBeenCalled()
+    expect(result).toContain('og:title')
+  })
+
+  it('includes og:url with the full URL', async () => {
+    const url = 'https://example.com/my-no1s?theme=test'
+    const params = new URLSearchParams({ theme: 'test' })
+    const result = await injectOgpTags(SAMPLE_HTML, url, params)
+
+    expect(result).toContain(`content="https://example.com/my-no1s?theme=test"`)
+  })
+
+  it('handles exception in fetchWorkTitle gracefully', async () => {
+    process.env['GOOGLE_BOOKS_API_KEY'] = 'test-key'
+
+    const { getBookById } = await import('../services/google-books.ts')
+    vi.mocked(getBookById).mockRejectedValue(new Error('Network error'))
+
+    const params = new URLSearchParams({
+      theme: 'テスト',
+      book: 'book1',
+    })
+    const result = await injectOgpTags(
+      SAMPLE_HTML,
+      'https://example.com/my-no1s',
+      params,
+    )
+
+    // Should not throw, should still return valid HTML with OGP tags
+    expect(result).toContain('og:title')
+    expect(result).toContain('</head>')
+  })
+})

--- a/src/server/ogp.ts
+++ b/src/server/ogp.ts
@@ -1,0 +1,151 @@
+import { getBookById } from '../services/google-books.ts'
+import type { SearchResultItem } from '../types/common.ts'
+
+const MAX_THEME_LENGTH = 50
+const DEFAULT_SITE_NAME = 'My No.1s'
+const DEFAULT_DESCRIPTION =
+  '本・音楽・映画からあなたのNo.1を選んで、みんなにシェアしよう！'
+
+type WorkInfo = {
+  title: string
+  category: string
+}
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+export function buildOgTitle(theme: string): string {
+  if (theme) {
+    return `${theme} | ${DEFAULT_SITE_NAME}`
+  }
+  return DEFAULT_SITE_NAME
+}
+
+export function buildOgDescription(works: WorkInfo[]): string {
+  if (works.length === 0) {
+    return DEFAULT_DESCRIPTION
+  }
+  const parts = works.map((w) => `${w.category}: ${w.title}`)
+  return parts.join(' / ')
+}
+
+export function buildMetaTags(options: {
+  title: string
+  description: string
+  url: string
+}): string {
+  const { title, description, url } = options
+  const tags = [
+    `<meta property="og:title" content="${escapeHtml(title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(description)}" />`,
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:url" content="${escapeHtml(url)}" />`,
+    `<meta property="og:site_name" content="${DEFAULT_SITE_NAME}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${escapeHtml(title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(description)}" />`,
+  ]
+  return tags.join('\n    ')
+}
+
+async function fetchWorkTitle(
+  category: 'book' | 'music' | 'movie',
+  id: string,
+): Promise<WorkInfo | null> {
+  const categoryLabels = { book: '📚Book', music: '🎵Music', movie: '🎬Movie' }
+
+  try {
+    let result: { ok: boolean; data?: SearchResultItem }
+
+    if (category === 'book') {
+      const apiKey = process.env['GOOGLE_BOOKS_API_KEY'] ?? ''
+      if (!apiKey) return null
+      result = await getBookById(apiKey, id)
+    } else if (category === 'music') {
+      const clientId = process.env['SPOTIFY_CLIENT_ID'] ?? ''
+      const clientSecret = process.env['SPOTIFY_CLIENT_SECRET'] ?? ''
+      if (!clientId || !clientSecret) return null
+      const { getAccessToken, getMusicById } =
+        await import('../services/spotify.ts')
+      const token = await getAccessToken(clientId, clientSecret)
+      if (!token.ok) return null
+      result = await getMusicById(token.data, id)
+    } else {
+      const apiKey = process.env['TMDB_API_KEY'] ?? ''
+      if (!apiKey) return null
+      const { getMovieById } = await import('../services/tmdb.ts')
+      result = await getMovieById(apiKey, id)
+    }
+
+    if (result.ok && result.data) {
+      return { title: result.data.title, category: categoryLabels[category] }
+    }
+  } catch (e) {
+    console.error(`[ogp] Failed to fetch ${category} (id: ${id}):`, e)
+  }
+  return null
+}
+
+export async function injectOgpTags(
+  html: string,
+  url: string,
+  searchParams: URLSearchParams,
+): Promise<string> {
+  const rawTheme = searchParams.get('theme') ?? ''
+  const theme = rawTheme.slice(0, MAX_THEME_LENGTH)
+  const bookId = searchParams.get('book') ?? ''
+  const musicId = searchParams.get('music') ?? ''
+  const movieId = searchParams.get('movie') ?? ''
+
+  const works: WorkInfo[] = []
+
+  // Fetch work titles in parallel
+  const fetchPromises: Promise<void>[] = []
+
+  if (bookId) {
+    fetchPromises.push(
+      fetchWorkTitle('book', bookId).then((w) => {
+        if (w) works.push(w)
+      }),
+    )
+  }
+  if (musicId) {
+    fetchPromises.push(
+      fetchWorkTitle('music', musicId).then((w) => {
+        if (w) works.push(w)
+      }),
+    )
+  }
+  if (movieId) {
+    fetchPromises.push(
+      fetchWorkTitle('movie', movieId).then((w) => {
+        if (w) works.push(w)
+      }),
+    )
+  }
+
+  // Wait with timeout to avoid blocking crawlers for too long
+  await Promise.race([
+    Promise.allSettled(fetchPromises),
+    new Promise((resolve) => setTimeout(resolve, 3000)),
+  ])
+
+  // Sort works in consistent order: book, music, movie
+  const categoryOrder = ['📚Book', '🎵Music', '🎬Movie']
+  works.sort(
+    (a, b) =>
+      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category),
+  )
+
+  const title = buildOgTitle(theme)
+  const description = buildOgDescription(works)
+  const metaTags = buildMetaTags({ title, description, url })
+
+  return html.replace('</head>', `    ${metaTags}\n  </head>`)
+}

--- a/src/server/prod.ts
+++ b/src/server/prod.ts
@@ -1,13 +1,40 @@
 import 'dotenv/config'
+import fs from 'node:fs'
+import path from 'node:path'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import api from './index.ts'
+import { injectOgpTags } from './ogp.ts'
 
 const app = new Hono()
 
 // Mount API routes
 app.route('/', api)
+
+// OGP meta tag injection for /my-no1s share URLs
+app.get('/my-no1s', async (c) => {
+  const indexPath = path.resolve('./dist/index.html')
+  let html: string
+  try {
+    html = fs.readFileSync(indexPath, 'utf-8')
+  } catch {
+    // Fallback to static serving if file not found
+    return c.notFound()
+  }
+
+  const url = c.req.url
+  const searchParams = new URL(url).searchParams
+
+  try {
+    html = await injectOgpTags(html, url, searchParams)
+  } catch (e) {
+    console.error('[ogp] Failed to inject OGP tags:', e)
+    // Return original HTML without OGP tags rather than failing
+  }
+
+  return c.html(html)
+})
 
 // Serve static files from dist/
 app.use('*', serveStatic({ root: './dist' }))


### PR DESCRIPTION
## Summary

`/my-no1s` の共有URLにOGP (Open Graph Protocol) メタタグを動的に注入し、X/LINEでシェアした際にタイトル・説明文が正しく表示されるようにします。

## Changes

### New: `src/server/ogp.ts`
- `injectOgpTags()` - HTMLに OGP メタタグを注入するメイン関数
- `escapeHtml()` - XSS防止のためのHTMLエスケープ
- `buildOgTitle()` - テーマ名を含むタイトル生成 (例: `夏の思い出 | My No.1s`)
- `buildOgDescription()` - 作品タイトルを含む説明文生成 (例: `📚Book: 1Q84 / 🎵Music: Shape of You / 🎬Movie: Inception`)
- `buildMetaTags()` - OGP/Twitter Cardメタタグ文字列を構築

### Modified: `src/server/prod.ts`
- `GET /my-no1s` ルートを追加し、静的ファイル配信の前にOGPタグ注入済みHTMLを返す

### Injected meta tags
- `og:title`, `og:description`, `og:type`, `og:url`, `og:site_name`
- `twitter:card`, `twitter:title`, `twitter:description`

### Key design decisions
- **Parallel API fetching**: Google Books, Spotify, TMDB APIに並列でリクエストし、作品タイトルを取得
- **3秒タイムアウト**: クローラーのブロックを防止
- **Graceful degradation**: API失敗時もデフォルトのメタタグ付きHTMLを返す（サーバーエラーにはならない）
- **HTML escaping**: 動的コンテンツはすべてHTMLエスケープしXSSを防止

### New: `src/server/ogp.test.ts`
- 22 unit tests covering escapeHtml, buildOgTitle, buildOgDescription, buildMetaTags, injectOgpTags

## Testing
- `npm test` - 275 tests all passing (22 new)
- `npm run format:check` - ✅

## Follow-up
- `og:image` のサーバーサイド画像生成（別issue）

Closes #118