### PR TITLE
feat: restore selection when returning from Top3 page

### DIFF
--- a/src/hooks/useRestoreSelection.test.ts
+++ b/src/hooks/useRestoreSelection.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useRestoreSelection } from './useRestoreSelection'
+import { createSearchResultItem } from '../test/fixtures'
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+// Mock selection context
+const mockSelectItem = vi.fn()
+vi.mock('./useSelection', () => ({
+  useSelection: () => ({
+    selection: { book: null, music: null, movie: null },
+    selectItem: mockSelectItem,
+    deselectItem: vi.fn(),
+    clearAll: vi.fn(),
+    isComplete: false,
+  }),
+}))
+
+describe('useRestoreSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does nothing when no IDs provided', () => {
+    renderHook(() => useRestoreSelection('', '', ''))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches and restores book when bookId is provided', async () => {
+    const bookItem = createSearchResultItem({
+      id: 'b1',
+      category: 'book',
+      title: 'Test Book',
+    })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true, data: bookItem }),
+    })
+
+    renderHook(() => useRestoreSelection('b1', '', ''))
+
+    await waitFor(() => {
+      expect(mockSelectItem).toHaveBeenCalledWith(bookItem)
+    })
+  })
+
+  it('fetches all three categories in parallel', async () => {
+    const bookItem = createSearchResultItem({ id: 'b1', category: 'book' })
+    const musicItem = createSearchResultItem({ id: 'm1', category: 'music' })
+    const movieItem = createSearchResultItem({ id: 'v1', category: 'movie' })
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, data: bookItem }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, data: musicItem }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, data: movieItem }),
+      })
+
+    renderHook(() => useRestoreSelection('b1', 'm1', 'v1'))
+
+    await waitFor(() => {
+      expect(mockSelectItem).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  it('handles fetch failure gracefully', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    renderHook(() => useRestoreSelection('b1', '', ''))
+
+    // Should not throw
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/hooks/useRestoreSelection.ts
+++ b/src/hooks/useRestoreSelection.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react'
+import type { MediaCategory } from '../types/common'
+import { API_ENDPOINTS } from '../constants/category'
+import { useSelection } from './useSelection'
+
+async function fetchAndRestore(
+  category: MediaCategory,
+  id: string,
+  selectItem: ReturnType<typeof useSelection>['selectItem'],
+): Promise<void> {
+  try {
+    const response = await fetch(`${API_ENDPOINTS[category]}/${id}`)
+    if (!response.ok) return
+    const result = await response.json()
+    if (result.ok && result.data) {
+      selectItem(result.data)
+    }
+  } catch (e) {
+    console.error(`[restore] Failed to fetch ${category} (id: ${id}):`, e)
+  }
+}
+
+export function useRestoreSelection(
+  bookId: string,
+  musicId: string,
+  movieId: string,
+): void {
+  const { selectItem } = useSelection()
+  const restoredRef = useRef(false)
+
+  useEffect(() => {
+    if (restoredRef.current) return
+    if (!bookId && !musicId && !movieId) return
+    restoredRef.current = true
+
+    const promises: Promise<void>[] = []
+    if (bookId) promises.push(fetchAndRestore('book', bookId, selectItem))
+    if (musicId) promises.push(fetchAndRestore('music', musicId, selectItem))
+    if (movieId) promises.push(fetchAndRestore('movie', movieId, selectItem))
+
+    Promise.allSettled(promises)
+  }, [bookId, musicId, movieId, selectItem])
+}

--- a/src/hooks/useSearchPage.ts
+++ b/src/hooks/useSearchPage.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import type { MediaCategory, SearchResultItem } from '../types/common'
 import { useDebounce } from './useDebounce'
 import { useSearch } from './useSearch'
@@ -6,6 +7,7 @@ import { useSearchHistory } from './useSearchHistory'
 import { useThemeHistory } from './useThemeHistory'
 import { useTheme } from './useTheme'
 import { useSelection } from './useSelection'
+import { useRestoreSelection } from './useRestoreSelection'
 
 type QueryState = Record<MediaCategory, string>
 
@@ -16,11 +18,36 @@ const INITIAL_QUERIES: QueryState = {
 }
 
 export function useSearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [activeTab, setActiveTab] = useState<MediaCategory>('book')
   const [queries, setQueries] = useState<QueryState>(INITIAL_QUERIES)
   const { theme, setTheme } = useTheme()
   const { selectItem } = useSelection()
   const { addHistory: addThemeHistory } = useThemeHistory()
+
+  // Restore selection from edit URL params
+  const isEdit = searchParams.get('edit') === '1'
+  const editBookId = searchParams.get('book') ?? ''
+  const editMusicId = searchParams.get('music') ?? ''
+  const editMovieId = searchParams.get('movie') ?? ''
+  const editTheme = searchParams.get('theme') ?? ''
+
+  useRestoreSelection(
+    isEdit ? editBookId : '',
+    isEdit ? editMusicId : '',
+    isEdit ? editMovieId : '',
+  )
+
+  // Restore theme and clear edit params from URL
+  const editProcessedRef = useRef(false)
+  useEffect(() => {
+    if (isEdit && !editProcessedRef.current) {
+      editProcessedRef.current = true
+      if (editTheme) setTheme(editTheme)
+      // Clean up edit params from URL
+      setSearchParams(new URLSearchParams(), { replace: true })
+    }
+  }, [isEdit, editTheme, setTheme, setSearchParams])
 
   const currentQuery = queries[activeTab]
   const debouncedQuery = useDebounce(currentQuery, 300)

--- a/src/pages/Top3Page.tsx
+++ b/src/pages/Top3Page.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams, Link } from 'react-router-dom'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
-import { parseTop3Params } from '../utils/url-params'
+import { parseTop3Params, buildEditUrl } from '../utils/url-params'
 import ErrorMessage from '../components/ErrorMessage'
 import ShareButtons from '../components/ShareButtons'
 import Top3Image from '../components/Top3Image'
@@ -169,7 +169,7 @@ function Top3Page() {
         <div className="mt-8 text-center">
           <Button
             component={Link}
-            to="/"
+            to={buildEditUrl(params)}
             variant="outlined"
             sx={{
               borderRadius: '9999px',

--- a/src/utils/url-params.test.ts
+++ b/src/utils/url-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildTop3Url, parseTop3Params } from './url-params'
+import { buildTop3Url, parseTop3Params, buildEditUrl } from './url-params'
 import { createSearchResultItem } from '../test/fixtures'
 import { MAX_THEME_LENGTH } from '../hooks/useTheme'
 
@@ -100,5 +100,38 @@ describe('parseTop3Params', () => {
     expect(parsed.musicId).toBe('m1')
     expect(parsed.movieId).toBe('v1')
     expect(parsed.theme).toBe('テスト')
+  })
+})
+
+describe('buildEditUrl', () => {
+  it('builds URL with edit flag and IDs', () => {
+    const url = buildEditUrl({
+      theme: 'test',
+      bookId: 'b1',
+      musicId: 'm1',
+      movieId: 'v1',
+    })
+    expect(url).toBe('/?edit=1&theme=test&book=b1&music=m1&movie=v1')
+  })
+
+  it('omits empty IDs', () => {
+    const url = buildEditUrl({
+      theme: '',
+      bookId: 'b1',
+      musicId: '',
+      movieId: '',
+    })
+    expect(url).toBe('/?edit=1&book=b1')
+  })
+
+  it('includes theme when present', () => {
+    const url = buildEditUrl({
+      theme: '夏の思い出',
+      bookId: '',
+      musicId: '',
+      movieId: '',
+    })
+    const params = new URLSearchParams(url.split('?')[1])
+    expect(params.get('theme')).toBe('夏の思い出')
   })
 })

--- a/src/utils/url-params.ts
+++ b/src/utils/url-params.ts
@@ -46,3 +46,23 @@ export function parseTop3Params(searchParams: URLSearchParams): Top3Params {
     movieId: searchParams.get('movie') ?? '',
   }
 }
+
+export function buildEditUrl(params: Top3Params): string {
+  const sp = new URLSearchParams()
+  sp.set('edit', '1')
+
+  if (params.theme) {
+    sp.set('theme', params.theme)
+  }
+  if (params.bookId) {
+    sp.set('book', params.bookId)
+  }
+  if (params.musicId) {
+    sp.set('music', params.musicId)
+  }
+  if (params.movieId) {
+    sp.set('movie', params.movieId)
+  }
+
+  return `/?${sp.toString()}`
+}


### PR DESCRIPTION
## Summary

Top3ページからトップページに戻った際に選択状態を保持する機能を追加。

## Changes

- `buildEditUrl()`: 選択IDをURLパラメータとして組み立てる関数
- `useRestoreSelection` hook: IDからAPI経由で作品データを取得し、SelectionContextに復元
- Top3Pageの「戻る」ボタンが選択状態をURLパラメータ経由で渡す
- SearchPageがeditパラメータを検出して選択状態+テーマを復元

## Tests
- `url-params.test.ts`: 3 new tests for buildEditUrl
- `useRestoreSelection.test.ts`: 4 new tests
- 全316テスト PASS ✅

Closes #120