### PR TITLE
fix: improve in-memory rate limiter safety

### DIFF
--- a/src/server/middleware/rate-limiter.test.ts
+++ b/src/server/middleware/rate-limiter.test.ts
@@ -39,3 +39,41 @@ describe('rateLimiter', () => {
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('9')
   })
 })
+
+it('evicts oldest entries when store exceeds maxStoreSize', async () => {
+  const app = new Hono()
+  app.use('*', rateLimiter({ windowMs: 60000, max: 100, maxStoreSize: 3 }))
+  app.get('/test', (c) => c.json({ ok: true }))
+
+  // Fill store with 4 different IPs (exceeds maxStoreSize of 3)
+  for (let i = 0; i < 4; i++) {
+    await app.request('/test', {
+      headers: { 'x-forwarded-for': `10.0.0.${i}` },
+    })
+  }
+
+  // First IP should have been evicted; its counter reset
+  const res = await app.request('/test', {
+    headers: { 'x-forwarded-for': '10.0.0.0' },
+  })
+  expect(res.status).toBe(200)
+  expect(res.headers.get('X-RateLimit-Remaining')).toBe('99')
+})
+
+it('uses first IP from x-forwarded-for when multiple present', async () => {
+  const app = new Hono()
+  app.use('*', rateLimiter({ windowMs: 60000, max: 2 }))
+  app.get('/test', (c) => c.json({ ok: true }))
+
+  // Same real IP with different proxy chains
+  await app.request('/test', {
+    headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.1' },
+  })
+  await app.request('/test', {
+    headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.2' },
+  })
+  const res = await app.request('/test', {
+    headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.3' },
+  })
+  expect(res.status).toBe(429)
+})

--- a/src/server/middleware/rate-limiter.ts
+++ b/src/server/middleware/rate-limiter.ts
@@ -1,12 +1,29 @@
 import type { MiddlewareHandler } from 'hono'
 
-type RateLimitStore = Map<string, { count: number; resetAt: number }>
+type RateLimitEntry = { count: number; resetAt: number }
+type RateLimitStore = Map<string, RateLimitEntry>
 
+const DEFAULT_MAX_STORE_SIZE = 10000
+
+/**
+ * In-memory rate limiter middleware.
+ *
+ * ## IP取得について
+ * - `x-forwarded-for` ヘッダの最初のIPを使用（リバースプロキシ経由のクライアントIP）
+ * - フォールバック: `x-real-ip` ヘッダ → 'unknown'
+ * - 信頼できるリバースプロキシ（Cloudflare, nginx等）の背後で動作することを前提
+ * - プロキシなしで直接公開する場合、ヘッダー偽装によるバイパスのリスクあり
+ *
+ * ## Storeサイズ制限
+ * - `maxStoreSize` でMapの上限を設定（デフォルト: 10,000）
+ * - 上限超過時は最も古いエントリを削除（FIFO）
+ */
 export function rateLimiter(options: {
   windowMs: number
   max: number
+  maxStoreSize?: number
 }): MiddlewareHandler {
-  const { windowMs, max } = options
+  const { windowMs, max, maxStoreSize = DEFAULT_MAX_STORE_SIZE } = options
   const store: RateLimitStore = new Map()
 
   // Clean up expired entries periodically
@@ -19,13 +36,34 @@ export function rateLimiter(options: {
     }
   }, windowMs).unref?.()
 
+  function getClientIp(c: Parameters<MiddlewareHandler>[0]): string {
+    const forwarded = c.req.header('x-forwarded-for')
+    if (forwarded) {
+      // Take the first IP (client IP set by the trusted proxy)
+      return forwarded.split(',')[0].trim()
+    }
+    return c.req.header('x-real-ip') ?? 'unknown'
+  }
+
+  function evictIfNeeded(): void {
+    while (store.size >= maxStoreSize) {
+      // Map iterates in insertion order; delete the oldest
+      const oldest = store.keys().next().value
+      if (oldest !== undefined) {
+        store.delete(oldest)
+      } else {
+        break
+      }
+    }
+  }
+
   return async (c, next) => {
-    const key =
-      c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip') ?? 'unknown'
+    const key = getClientIp(c)
     const now = Date.now()
     const record = store.get(key)
 
     if (!record || now > record.resetAt) {
+      evictIfNeeded()
       store.set(key, { count: 1, resetAt: now + windowMs })
       c.header('X-RateLimit-Limit', String(max))
       c.header('X-RateLimit-Remaining', String(max - 1))


### PR DESCRIPTION
## Summary

インメモリRate Limiterの安全性を改善。

## Changes
- **Mapサイズ上限**: `maxStoreSize` オプション追加（デフォルト10,000件）。超過時はFIFO方式で最古エントリを削除
- **IP取得改善**: `x-forwarded-for` から最初のIPのみ抽出（`1.2.3.4, 10.0.0.1` → `1.2.3.4`）
- **ドキュメント**: IP取得方法・信頼性の前提をJSDocに記載

## Tests
- 2 new tests (store eviction, multi-IP forwarded header)
- 全311テスト PASS ✅

Closes #134