### PR TITLE
fix: add URL parameter ID validation

### DIFF
--- a/src/utils/url-params.test.ts
+++ b/src/utils/url-params.test.ts
@@ -135,3 +135,32 @@ describe('buildEditUrl', () => {
     expect(params.get('theme')).toBe('夏の思い出')
   })
 })
+
+describe('parseTop3Params - ID validation', () => {
+  it('rejects IDs with special characters', () => {
+    const params = new URLSearchParams(
+      'book=../etc/passwd&music=<script>&movie=1; DROP TABLE',
+    )
+    const result = parseTop3Params(params)
+    expect(result.bookId).toBe('')
+    expect(result.musicId).toBe('')
+    expect(result.movieId).toBe('')
+  })
+
+  it('accepts valid alphanumeric IDs', () => {
+    const params = new URLSearchParams(
+      'book=vol-123_abc&music=4iV5W9uYEdYUVa79Axb7Rh&movie=12345',
+    )
+    const result = parseTop3Params(params)
+    expect(result.bookId).toBe('vol-123_abc')
+    expect(result.musicId).toBe('4iV5W9uYEdYUVa79Axb7Rh')
+    expect(result.movieId).toBe('12345')
+  })
+
+  it('rejects empty-looking malicious IDs', () => {
+    const params = new URLSearchParams('book=   &music=%00null')
+    const result = parseTop3Params(params)
+    expect(result.bookId).toBe('')
+    expect(result.musicId).toBe('')
+  })
+})

--- a/src/utils/url-params.ts
+++ b/src/utils/url-params.ts
@@ -1,6 +1,12 @@
 import type { SearchResultItem } from '../types/common'
 import { MAX_THEME_LENGTH } from '../hooks/useTheme'
 
+/** Validates that an ID contains only safe characters (alphanumeric, hyphen, underscore) */
+function sanitizeId(raw: string): string {
+  const trimmed = raw.trim()
+  return /^[\w-]+$/.test(trimmed) ? trimmed : ''
+}
+
 type Selection = {
   book: SearchResultItem | null
   music: SearchResultItem | null
@@ -41,9 +47,9 @@ export function parseTop3Params(searchParams: URLSearchParams): Top3Params {
   const rawTheme = searchParams.get('theme') ?? ''
   return {
     theme: rawTheme.slice(0, MAX_THEME_LENGTH),
-    bookId: searchParams.get('book') ?? '',
-    musicId: searchParams.get('music') ?? '',
-    movieId: searchParams.get('movie') ?? '',
+    bookId: sanitizeId(searchParams.get('book') ?? ''),
+    musicId: sanitizeId(searchParams.get('music') ?? ''),
+    movieId: sanitizeId(searchParams.get('movie') ?? ''),
   }
 }
 


### PR DESCRIPTION
## Summary

クライアント側でURLパラメータのIDバリデーションを追加。

## Changes
- `sanitizeId()`: `[\w-]+` パターンに一致しないIDを空文字にフォールバック
- パス・トラバーサル、XSS、SQLインジェクション等の不正IDを早期リジェクト
- サーバー側の既存バリデーション（Google Books: `[\w-]+`, Spotify: `[\w]+`, TMDb: `\d+`）と一貫性あり

## Tests
- 3 new tests for ID validation
- 全312テスト PASS ✅

Closes #136