### PR TITLE
refactor: consolidate hardcoded Japanese messages

### DIFF
--- a/src/constants/messages.test.ts
+++ b/src/constants/messages.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { MESSAGES } from './messages'
+
+describe('MESSAGES', () => {
+  it('has RATE_LIMITED as a string', () => {
+    expect(typeof MESSAGES.RATE_LIMITED).toBe('string')
+    expect(MESSAGES.RATE_LIMITED.length).toBeGreaterThan(0)
+  })
+
+  it('FETCH_FAILED returns formatted message', () => {
+    expect(MESSAGES.FETCH_FAILED('書籍')).toBe('書籍の取得に失敗しました')
+  })
+
+  it('NOT_FOUND returns formatted message with ID', () => {
+    expect(MESSAGES.NOT_FOUND('書籍', 'abc123')).toBe(
+      '書籍が見つかりませんでした (ID: abc123)',
+    )
+  })
+
+  it('all static messages are non-empty strings', () => {
+    const staticKeys = Object.entries(MESSAGES).filter(
+      ([, v]) => typeof v === 'string',
+    )
+    for (const [key, value] of staticKeys) {
+      expect(value, `MESSAGES.${key}`).toBeTruthy()
+    }
+  })
+})

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,28 @@
+/**
+ * アプリ全体の日本語メッセージ定数
+ * 将来の多言語対応への布石として一元管理
+ */
+export const MESSAGES = {
+  // Error messages
+  RATE_LIMITED: 'しばらく時間をおいて再度お試しください',
+  FETCH_FAILED: (label: string) => `${label}の取得に失敗しました`,
+  NOT_FOUND: (label: string, id: string) =>
+    `${label}が見つかりませんでした (ID: ${id})`,
+  IMAGE_CORS_ERROR:
+    '画像の取得に失敗しました。外部画像のCORS設定が原因の可能性があります。',
+  NO_SEARCH_RESULTS: '検索結果が見つかりませんでした',
+
+  // UI labels
+  UNSELECTED: '未選択',
+  SELECTED_WORKS: '選択中の作品',
+  CREATE_TOP3: 'Top3を作成',
+  CREATE_TOP3_EMOJI: 'Top3を作成 🎉',
+  CREATE_TOP3_CTA: 'Top3を作成する',
+  BACK_TO_TOP: '← トップページに戻る',
+  BACK_TO_TOP_SIMPLE: 'トップページに戻る',
+  DOWNLOAD_IMAGE: '画像をダウンロード',
+  GENERATING: '生成中...',
+  IMAGE_SAVED: '画像を保存しました',
+  NO_WORKS_SELECTED:
+    '作品が選択されていません。トップページから3作品を選んでください。',
+} as const

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { MediaCategory, SearchResultItem } from '../types/common'
+import { MESSAGES } from '../constants/messages'
 
 const MAX_RESULTS = 20
 
@@ -69,7 +70,7 @@ export function useSearch(
 
         if (!response.ok) {
           if (response.status === 429) {
-            throw new Error('しばらく時間をおいて再度お試しください')
+            throw new Error(MESSAGES.RATE_LIMITED)
           }
           throw new Error(`HTTP ${response.status}`)
         }

--- a/src/hooks/useWorkFetch.ts
+++ b/src/hooks/useWorkFetch.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import type { MediaCategory, SearchResultItem } from '../types/common'
 import { CATEGORY_LABELS_JA, API_ENDPOINTS } from '../constants/category'
+import { MESSAGES } from '../constants/messages'
 
 type WorkState = {
   data: SearchResultItem | null
@@ -15,14 +16,12 @@ async function fetchWork(
   const response = await fetch(`${API_ENDPOINTS[category]}/${id}`)
   if (!response.ok) {
     if (response.status === 404) {
-      throw new Error(
-        `${CATEGORY_LABELS_JA[category]}が見つかりませんでした (ID: ${id})`,
-      )
+      throw new Error(MESSAGES.NOT_FOUND(CATEGORY_LABELS_JA[category], id))
     }
     if (response.status === 429) {
-      throw new Error('しばらく時間をおいて再度お試しください')
+      throw new Error(MESSAGES.RATE_LIMITED)
     }
-    throw new Error(`${CATEGORY_LABELS_JA[category]}の取得に失敗しました`)
+    throw new Error(MESSAGES.FETCH_FAILED(CATEGORY_LABELS_JA[category]))
   }
 
   const result = await response.json()
@@ -31,7 +30,7 @@ async function fetchWork(
   if (!result.ok) {
     throw new Error(
       result.error?.message ??
-        `${CATEGORY_LABELS_JA[category]}の取得に失敗しました`,
+        MESSAGES.FETCH_FAILED(CATEGORY_LABELS_JA[category]),
     )
   }
 
@@ -65,7 +64,7 @@ export function useWorkFetch(category: MediaCategory, id: string) {
             error:
               err instanceof Error
                 ? err.message
-                : `${CATEGORY_LABELS_JA[category]}の取得に失敗しました`,
+                : MESSAGES.FETCH_FAILED(CATEGORY_LABELS_JA[category]),
           })
         }
       })

--- a/src/utils/image-helpers.ts
+++ b/src/utils/image-helpers.ts
@@ -1,3 +1,5 @@
+import { MESSAGES } from '../constants/messages'
+
 export function sanitizeFilename(name: string): string {
   return name
     .replace(/[/\\:*?"<>|\0\n\r]/g, '_')
@@ -8,7 +10,7 @@ export function sanitizeFilename(name: string): string {
 
 export function getImageErrorMessage(err: unknown): string {
   if (err instanceof DOMException && err.name === 'SecurityError') {
-    return '画像の取得に失敗しました。外部画像のCORS設定が原因の可能性があります。'
+    return MESSAGES.IMAGE_CORS_ERROR
   }
   if (err instanceof DOMException && err.name === 'QuotaExceededError') {
     return '画像サイズが大きすぎるため生成できませんでした。'


### PR DESCRIPTION
## Summary

ハードコードされた日本語メッセージを定数ファイルに集約。

## Changes
- `src/constants/messages.ts`: メッセージ定数を一元管理
- `useSearch.ts`, `useWorkFetch.ts`: 重複していた「しばらく時間をおいて〜」等を定数に置換
- `image-helpers.ts`: CORS エラーメッセージを定数に置換
- 将来の多言語対応への布石

## Tests
- 4 new tests for messages constants
- 全313テスト PASS ✅

Closes #135