### PR TITLE
feat: enhance empty state design with emotional UI

### DIFF
--- a/src/components/SearchResults.test.tsx
+++ b/src/components/SearchResults.test.tsx
@@ -24,15 +24,20 @@ describe('SearchResults', () => {
     query: '',
   }
 
-  it('shows prompt when query is empty', () => {
+  it('shows emotional prompt with emoji when query is empty', () => {
     render(<SearchResults {...defaultProps} query="" />)
-    expect(screen.getByText('作品名を検索してください')).toBeInTheDocument()
+    expect(
+      screen.getByText('お気に入りの作品を検索してみよう'),
+    ).toBeInTheDocument()
   })
 
-  it('shows no results message', () => {
+  it('shows no results with suggestion message', () => {
     render(<SearchResults {...defaultProps} query="test" />)
     expect(
       screen.getByText('検索結果が見つかりませんでした'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('別のキーワードで試してみよう 🔍'),
     ).toBeInTheDocument()
   })
 

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -42,22 +42,39 @@ export default function SearchResults({
 
   if (!query.trim()) {
     return (
-      <Box className="mt-8 text-center">
-        <Typography color="text.secondary">作品名を検索してください</Typography>
-      </Box>
+      <div className="mt-8 text-center">
+        <p className="text-4xl" aria-hidden="true">
+          🎨
+        </p>
+        <p
+          className="mt-2 text-sm font-medium"
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
+          お気に入りの作品を検索してみよう
+        </p>
+      </div>
     )
   }
 
   if (!isLoading && results.length === 0) {
     return (
-      <Box className="mt-8 text-center">
-        <Typography color="text.secondary">
+      <div className="mt-8 text-center">
+        <p className="text-4xl" aria-hidden="true">
+          😔
+        </p>
+        <p
+          className="mt-2 text-sm font-medium"
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
           検索結果が見つかりませんでした
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-          別のキーワードでお試しください
-        </Typography>
-      </Box>
+        </p>
+        <p
+          className="mt-1 text-xs"
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
+          別のキーワードで試してみよう 🔍
+        </p>
+      </div>
     )
   }
 

--- a/src/components/SelectionArea.test.tsx
+++ b/src/components/SelectionArea.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '../test/test-utils'
+import userEvent from '@testing-library/user-event'
 import SelectionArea from './SelectionArea'
 
 describe('SelectionArea', () => {
@@ -21,4 +22,13 @@ describe('SelectionArea', () => {
     )
     expect(slotContainer).toBeInTheDocument()
   })
+})
+
+it('calls onSlotClick with category when empty slot is clicked', async () => {
+  const user = userEvent.setup()
+  const onSlotClick = vi.fn()
+  render(<SelectionArea theme="" onSlotClick={onSlotClick} />)
+  const bookSlot = screen.getByRole('button', { name: /Book.*選ぶ/ })
+  await user.click(bookSlot)
+  expect(onSlotClick).toHaveBeenCalledWith('book')
 })

--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -20,45 +20,52 @@ type SelectionAreaProps = {
   theme: string
   onBeforeCreate?: () => void
   onCompleteChange?: (isComplete: boolean) => void
+  onSlotClick?: (category: MediaCategory) => void
 }
 
 function SlotCard({
   category,
   item,
   onDeselect,
+  onSlotClick,
 }: {
   category: MediaCategory
   item: SearchResultItem | null
   onDeselect: (category: MediaCategory) => void
+  onSlotClick?: (category: MediaCategory) => void
 }) {
   if (!item) {
     return (
-      <div
-        className="gradient-border-slot flex h-20 flex-1 flex-col items-center justify-center rounded-xl p-2 transition-all sm:h-28"
+      <button
+        type="button"
+        className="gradient-border-slot flex h-20 flex-1 cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-2 transition-all hover:opacity-80 sm:h-28"
         style={{
           backgroundColor: 'var(--color-surface)',
+          borderColor: 'var(--color-border)',
         }}
+        onClick={() => onSlotClick?.(category)}
+        aria-label={`${CATEGORY_LABELS_EN[category]}を選ぶ`}
       >
         <span
-          className="pointer-events-none select-none text-2xl opacity-15 sm:text-3xl"
+          className="pointer-events-none select-none text-2xl sm:text-3xl"
+          style={{ opacity: 0.3 }}
           aria-hidden="true"
         >
           {CATEGORY_ICONS[category]}
         </span>
-        <Typography
-          variant="caption"
-          sx={{ fontSize: '0.75rem', fontWeight: 600 }}
+        <span
+          className="text-xs font-semibold"
           style={{ color: 'var(--color-text-secondary)' }}
         >
           {CATEGORY_LABELS_EN[category]}
-        </Typography>
-        <Typography
-          variant="caption"
+        </span>
+        <span
+          className="text-xs"
           style={{ color: 'var(--color-text-secondary)' }}
         >
           未選択
-        </Typography>
-      </div>
+        </span>
+      </button>
     )
   }
 
@@ -118,6 +125,7 @@ function SelectionArea({
   theme,
   onBeforeCreate,
   onCompleteChange,
+  onSlotClick,
 }: SelectionAreaProps) {
   const { selection, deselectItem, isComplete } = useSelection()
   const navigate = useNavigate()
@@ -159,16 +167,19 @@ function SelectionArea({
           category="book"
           item={selection.book}
           onDeselect={deselectItem}
+          onSlotClick={onSlotClick}
         />
         <SlotCard
           category="music"
           item={selection.music}
           onDeselect={deselectItem}
+          onSlotClick={onSlotClick}
         />
         <SlotCard
           category="movie"
           item={selection.movie}
           onDeselect={deselectItem}
+          onSlotClick={onSlotClick}
         />
       </div>
       {isComplete && (

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -103,6 +103,7 @@ function SearchPage() {
             theme={theme}
             onBeforeCreate={handleBeforeCreate}
             onCompleteChange={handleCompleteChange}
+            onSlotClick={setActiveTab}
           />
         </div>
 


### PR DESCRIPTION
## Summary

空状態のエモーショナルデザインを強化。

## Changes
- **検索前**: 🎨 + 「お気に入りの作品を検索してみよう」
- **検索結果0件**: 😔 + 「別のキーワードで試してみよう 🔍」
- **未選択スロット**: 破線ボーダー + クリック可能 → 該当カテゴリのタブに自動切替

## Tests
- Updated SearchResults tests for new empty state messages
- New SelectionArea test for slot click callback
- 全319テスト PASS ✅

Closes #123