### PR TITLE
fix: X(Twitter)シェア時にURLが表示されない問題を修正

### DIFF
--- a/src/components/ShareButtons.test.tsx
+++ b/src/components/ShareButtons.test.tsx
@@ -119,7 +119,7 @@ describe('ShareButtons', () => {
       expect(screen.queryByLabelText('シェア')).not.toBeInTheDocument()
     })
 
-    it('shares text and URL with theme', async () => {
+    it('shares text and URL with theme (URL embedded in text)', async () => {
       const shareMock = vi.fn().mockResolvedValue(undefined)
       Object.assign(navigator, { share: shareMock })
 
@@ -129,13 +129,13 @@ describe('ShareButtons', () => {
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
           title: 'My No.1s',
-          text: '「雨の日に」 #MyNo1s',
+          text: `「雨の日に」 #MyNo1s\n${window.location.href}`,
           url: window.location.href,
         })
       })
     })
 
-    it('shares text and URL without theme', async () => {
+    it('shares text and URL without theme (URL embedded in text)', async () => {
       const shareMock = vi.fn().mockResolvedValue(undefined)
       Object.assign(navigator, { share: shareMock })
 
@@ -145,7 +145,7 @@ describe('ShareButtons', () => {
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
           title: 'My No.1s',
-          text: '#MyNo1s',
+          text: `#MyNo1s\n${window.location.href}`,
           url: window.location.href,
         })
       })
@@ -168,7 +168,7 @@ describe('ShareButtons', () => {
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            text: '「テスト」 #MyNo1s',
+            text: `「テスト」 #MyNo1s\n${window.location.href}`,
             url: window.location.href,
             files: expect.arrayContaining([expect.any(File)]),
           }),
@@ -220,7 +220,7 @@ describe('ShareButtons', () => {
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
           title: 'My No.1s',
-          text: '「テスト」 #MyNo1s',
+          text: `「テスト」 #MyNo1s\n${window.location.href}`,
           url: window.location.href,
         })
       })
@@ -240,7 +240,7 @@ describe('ShareButtons', () => {
       await waitFor(() => {
         expect(shareMock).toHaveBeenCalledWith({
           title: 'My No.1s',
-          text: '「テスト」 #MyNo1s',
+          text: `「テスト」 #MyNo1s\n${window.location.href}`,
           url: window.location.href,
         })
       })

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -14,8 +14,9 @@ type ShareButtonsProps = {
   preGeneratedBlob?: Blob | null
 }
 
-function buildShareText(theme?: string): string {
-  return theme ? `「${theme}」 #MyNo1s` : '#MyNo1s'
+function buildShareText(theme?: string, url?: string): string {
+  const base = theme ? `「${theme}」 #MyNo1s` : '#MyNo1s'
+  return url ? `${base}\n${url}` : base
 }
 
 export default function ShareButtons({
@@ -73,7 +74,7 @@ export default function ShareButtons({
           navigator.canShare({ files: [file] })
         ) {
           await navigator.share({
-            text: buildShareText(theme),
+            text: buildShareText(theme, window.location.href),
             url: window.location.href,
             files: [file],
           })
@@ -84,7 +85,7 @@ export default function ShareButtons({
       // Fallback: text + URL only
       await navigator.share({
         title: 'My No.1s',
-        text: buildShareText(theme),
+        text: buildShareText(theme, window.location.href),
         url: window.location.href,
       })
     } catch (error) {


### PR DESCRIPTION
## 問題

Web Share APIでシェアする際、X(Twitter)ではURLが表示されなかった。

## 原因

Web Share APIの `text` と `url` を別パラメータで渡すと、X(Twitter)は `url` を無視する既知の挙動がある。

## 修正内容

`buildShareText()` で生成するテキスト内にURLを埋め込むようにした。

```diff
- 「雨の日に」 #MyNo1s
+ 「雨の日に」 #MyNo1s
+ https://myno1s.exe.xyz/...
```

- `url` パラメータも引き続き渡し、他アプリ（LINEなど）との互換性を維持
- テスト更新済み（18テスト全パス）