### PR TITLE
feat: Amazonアソシエイト開示文をDataCreditsフッターに追加

### DIFF
--- a/src/components/DataCredits.test.tsx
+++ b/src/components/DataCredits.test.tsx
@@ -45,3 +45,12 @@ describe('DataCredits', () => {
     expect(img).toBeInTheDocument()
   })
 })
+
+it('renders Amazon associate disclosure text', () => {
+  render(<DataCredits />)
+  expect(
+    screen.getByText(
+      /Amazonのアソシエイトとして.*適格販売により収入を得ています/,
+    ),
+  ).toBeInTheDocument()
+})

--- a/src/components/DataCredits.tsx
+++ b/src/components/DataCredits.tsx
@@ -56,6 +56,13 @@ function DataCredits() {
           This product uses the TMDB API but is not endorsed or certified by
           TMDB. Music data is provided by Last.fm.
         </p>
+
+        <p
+          className="mt-2 text-xs leading-relaxed"
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
+          Amazonのアソシエイトとして、当サイトは適格販売により収入を得ています。
+        </p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## 概要

Amazonアソシエイト・プログラム運営規約で義務付けられている開示文をDataCreditsフッターに追加。

## 変更内容

- `DataCredits.tsx`: 「Amazonのアソシエイトとして、当サイトは適格販売により収入を得ています。」の開示文を追加
- `DataCredits.test.tsx`: 開示文の表示テストを追加

closes #172