### PR TITLE
fix: TMDb検索のN+1 API問題を解消 — 監督名取得を廃止し公開年を表示

### DIFF
--- a/src/services/tmdb.test.ts
+++ b/src/services/tmdb.test.ts
@@ -43,7 +43,7 @@ describe('searchMovies', () => {
     })
   })
 
-  it('maps TMDb response correctly with director name', async () => {
+  it('maps TMDb response correctly with release year as subtitle', async () => {
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
         HttpResponse.json({
@@ -52,9 +52,6 @@ describe('searchMovies', () => {
           total_pages: 1,
           total_results: 1,
         }),
-      ),
-      http.get(`${BASE_URL}/movie/:id`, () =>
-        HttpResponse.json(mockMovieDetail()),
       ),
     )
     const result = await searchMovies('key', 'test')
@@ -64,11 +61,11 @@ describe('searchMovies', () => {
       expect(result.data.items[0].category).toBe('movie')
       expect(result.data.items[0].title).toBe('Test Movie')
       expect(result.data.items[0].thumbnailUrl).toContain('/poster.jpg')
-      expect(result.data.items[0].subtitle).toBe('Test Director')
+      expect(result.data.items[0].subtitle).toBe('2024')
     }
   })
 
-  it('shows 監督不明 when credits fetch fails', async () => {
+  it('shows empty subtitle when release_date is missing', async () => {
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
         HttpResponse.json({
@@ -78,31 +75,10 @@ describe('searchMovies', () => {
           total_results: 1,
         }),
       ),
-      http.get(`${BASE_URL}/movie/:id`, () => HttpResponse.error()),
     )
     const result = await searchMovies('key', 'test')
     if (result.ok) {
-      expect(result.data.items[0].subtitle).toBe('監督不明')
-    }
-  })
-
-  it('shows 監督不明 when no Director in crew', async () => {
-    server.use(
-      http.get(`${BASE_URL}/search/movie`, () =>
-        HttpResponse.json({
-          page: 1,
-          results: [mockMovie()],
-          total_pages: 1,
-          total_results: 1,
-        }),
-      ),
-      http.get(`${BASE_URL}/movie/:id`, () =>
-        HttpResponse.json(mockMovieDetail({ credits: { crew: [] } })),
-      ),
-    )
-    const result = await searchMovies('key', 'test')
-    if (result.ok) {
-      expect(result.data.items[0].subtitle).toBe('監督不明')
+      expect(result.data.items[0].subtitle).toBe('')
     }
   })
 
@@ -116,9 +92,6 @@ describe('searchMovies', () => {
           total_results: 1,
         }),
       ),
-      http.get(`${BASE_URL}/movie/:id`, () =>
-        HttpResponse.json(mockMovieDetail()),
-      ),
     )
     const result = await searchMovies('key', 'test')
     if (result.ok) {
@@ -126,10 +99,10 @@ describe('searchMovies', () => {
     }
   })
 
-  it('fetches director info for multiple movies in parallel', async () => {
+  it('does not make additional API calls for director info', async () => {
     const movies = [
-      mockMovie({ id: 1, title: 'Movie A' }),
-      mockMovie({ id: 2, title: 'Movie B' }),
+      mockMovie({ id: 1, title: 'Movie A', release_date: '2023-05-15' }),
+      mockMovie({ id: 2, title: 'Movie B', release_date: '2024-11-20' }),
     ]
     server.use(
       http.get(`${BASE_URL}/search/movie`, () =>
@@ -140,35 +113,19 @@ describe('searchMovies', () => {
           total_results: 2,
         }),
       ),
-      http.get(`${BASE_URL}/movie/1`, () =>
-        HttpResponse.json(
-          mockMovieDetail({
-            id: 1,
-            title: 'Movie A',
-            credits: {
-              crew: [{ id: 10, name: 'Director A', job: 'Director' }],
-            },
-          }),
-        ),
-      ),
-      http.get(`${BASE_URL}/movie/2`, () =>
-        HttpResponse.json(
-          mockMovieDetail({
-            id: 2,
-            title: 'Movie B',
-            credits: {
-              crew: [{ id: 20, name: 'Director B', job: 'Director' }],
-            },
-          }),
-        ),
-      ),
+      // No movie/:id handler — should NOT be called
+      http.get(`${BASE_URL}/movie/:id`, () => {
+        throw new Error(
+          'Should not fetch individual movie details during search',
+        )
+      }),
     )
     const result = await searchMovies('key', 'test')
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.data.items).toHaveLength(2)
-      expect(result.data.items[0].subtitle).toBe('Director A')
-      expect(result.data.items[1].subtitle).toBe('Director B')
+      expect(result.data.items[0].subtitle).toBe('2023')
+      expect(result.data.items[1].subtitle).toBe('2024')
     }
   })
 })

--- a/src/services/tmdb.ts
+++ b/src/services/tmdb.ts
@@ -122,10 +122,7 @@ export async function searchMovies(
   const { total_results, results } = result.data
   const sliced = sliceResultsForOffset(results, startIndex, maxResults)
 
-  const directorNames = await fetchDirectorNames(apiKey, sliced, signal)
-  const mapped = sliced.map((movie, i) =>
-    mapMovieToSearchResult(movie, directorNames[i]),
-  )
+  const mapped = sliced.map((movie) => mapMovieToSearchResult(movie))
 
   return {
     ok: true,
@@ -165,52 +162,20 @@ export async function getMovieById(
   return { ok: true, data: mapMovieDetailToSearchResult(result.data) }
 }
 
-// ── Director fetching ───────────────────────────────────────────────
-
-async function fetchDirectorName(
-  apiKey: string,
-  movieId: number,
-  signal?: AbortSignal,
-): Promise<string | undefined> {
-  const params = new URLSearchParams({
-    api_key: apiKey,
-    language: 'ja-JP',
-    append_to_response: 'credits',
-  })
-
-  const result = await fetchJson<TMDbMovieDetail>(
-    `${BASE_URL}/movie/${movieId}?${params.toString()}`,
-    { signal, validate: validateMovieDetail },
-  )
-
-  if (!result.ok) return undefined
-
-  const director = result.data.credits?.crew.find((c) => c.job === 'Director')
-  return director?.name
-}
-
-async function fetchDirectorNames(
-  apiKey: string,
-  movies: TMDbMovie[],
-  signal?: AbortSignal,
-): Promise<(string | undefined)[]> {
-  const results = await Promise.allSettled(
-    movies.map((movie) => fetchDirectorName(apiKey, movie.id, signal)),
-  )
-  return results.map((r) => (r.status === 'fulfilled' ? r.value : undefined))
-}
-
 // ── Mapping ─────────────────────────────────────────────────────────
 
-function mapMovieToSearchResult(
-  movie: TMDbMovie,
-  directorName?: string,
-): SearchResultItem {
+function extractYear(releaseDate?: string): string {
+  if (!releaseDate) return ''
+  const year = releaseDate.slice(0, 4)
+  return /^\d{4}$/.test(year) ? year : ''
+}
+
+function mapMovieToSearchResult(movie: TMDbMovie): SearchResultItem {
   return {
     id: String(movie.id),
     category: 'movie',
     title: movie.title || 'タイトル不明',
-    subtitle: directorName ?? '監督不明',
+    subtitle: extractYear(movie.release_date),
     thumbnailUrl: movie.poster_path
       ? `${IMAGE_BASE_URL}${movie.poster_path}`
       : '',

--- a/src/test/msw/handlers.ts
+++ b/src/test/msw/handlers.ts
@@ -102,7 +102,7 @@ export const handlers = [
             id: 'movie-1',
             category: 'movie',
             title: `Movie: ${q}`,
-            subtitle: 'Director Name',
+            subtitle: '2024',
             thumbnailUrl: 'https://example.com/movie.jpg',
             externalUrl: 'https://www.imdb.com/title/tt1234567',
           },


### PR DESCRIPTION
## 概要

TMDb検索で各映画の監督名を個別APIで取得していたN+1問題を修正。

Closes #170

## 変更内容

- `searchMovies()` から `fetchDirectorNames()` 呼び出しを削除
- 検索結果の subtitle に公開年（`release_date`）を表示するよう変更
- `fetchDirectorName` / `fetchDirectorNames` 関数を削除
- `getMovieById()` は従来通り `append_to_response=credits` で監督名を取得（変更なし）

## 効果

検索1回あたりのAPIコール: **21回 → 1回** に削減

| | Before | After |
|---|---|---|
| 検索API | 1回 | 1回 |
| 監督名取得API | 最大20回 | 0回 |
| **合計** | **最大21回** | **1回** |

## テスト

- 検索結果の subtitle が公開年になることを検証
- `release_date` 未設定時に空文字になることを検証
- 検索時に個別映画APIが呼ばれないことを検証（MSWでエラーを投げて確認）
