### PR TITLE
fix: 生成画像内にTMDb/Last.fmのデータクレジットを追加

### DIFF
--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -219,6 +219,19 @@ describe('Top3Image', () => {
       expect(screen.getAllByText('No Data')).toHaveLength(3)
     })
 
+    it('displays data credits text in the capture area', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+      const captureArea = screen.getByTestId('top3-image-capture')
+      expect(captureArea).toHaveTextContent('Data by TMDb & Last.fm')
+    })
+
     it('handles mixed null and non-null items', () => {
       render(
         <Top3Image theme="" book={mockBook} music={null} movie={mockMovie} />,

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -143,7 +143,7 @@ function Top3Image({
               slot="bottom-right"
             />
 
-            {/* Branding */}
+            {/* Branding & Data Credits */}
             <div
               style={{
                 position: 'absolute',
@@ -165,6 +165,18 @@ function Top3Image({
               >
                 my-no1s.app
               </span>
+              <div
+                style={{
+                  fontSize: 9,
+                  color: 'rgba(255,255,255,0.15)',
+                  letterSpacing: 1,
+                  fontWeight: 400,
+                  marginTop: 2,
+                  textShadow: '0 1px 4px rgba(0,0,0,0.5)',
+                }}
+              >
+                Data by TMDb &amp; Last.fm
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要

生成画像がSNSで単独流通した際に、データ提供元（TMDb / Last.fm）の帰属表示が失われる問題を修正。

## 変更内容

- キャプチャエリア下部のブランディング（`my-no1s.app`）直下に `Data by TMDb & Last.fm` テキストを追加
- フォントサイズ 9px、半透明白色（`rgba(255,255,255,0.15)`）で控えめに表示
- テスト追加（クレジットテキストがキャプチャエリア内に存在することを検証）

## テスト結果

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (421 passed)

Closes #173