### PR TITLE
refactor: スタイリングガイドライン違反の修正 (#174)

### DIFF
--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -1,9 +1,7 @@
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardMedia from '@mui/material/CardMedia'
-import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
-import Box from '@mui/material/Box'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 import type { SearchResultItem, MediaCategory } from '../types/common'
@@ -54,14 +52,13 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
           handleCardClick()
         }
       }}
+      className={`flex transition-all duration-200 ease-in-out ${
+        isSelected ? 'cursor-default opacity-[0.85]' : 'cursor-pointer'
+      }`}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
       sx={{
-        display: 'flex',
-        transition: 'all 0.2s ease',
-        cursor: isSelected ? 'default' : 'pointer',
-        WebkitTapHighlightColor: 'transparent',
         ...(isSelected && {
           border: (theme) => `2px solid ${theme.palette.primary.main}`,
-          opacity: 0.85,
         }),
         '&:focus-visible': {
           outline: '2px solid',
@@ -79,7 +76,7 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
         }),
       }}
     >
-      <Box sx={{ position: 'relative', flexShrink: 0 }}>
+      <div className="relative shrink-0">
         <CardMedia
           component="img"
           sx={{
@@ -95,56 +92,19 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
           }}
         />
         {isSelected && (
-          <Box
-            sx={{
-              position: 'absolute',
-              inset: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              bgcolor: 'rgba(0, 0, 0, 0.4)',
-            }}
-          >
+          <div className="absolute inset-0 flex items-center justify-center bg-black/40">
             <CheckCircleIcon sx={{ color: 'white', fontSize: 32 }} />
-          </Box>
+          </div>
         )}
-      </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minWidth: 0,
-        }}
-      >
+      </div>
+      <div className="flex flex-col flex-1 min-w-0">
         <CardContent sx={{ flex: 1, py: 1.5, '&:last-child': { pb: 1.5 } }}>
-          <Typography
-            variant="subtitle1"
-            component="h3"
-            sx={{
-              fontWeight: 600,
-              lineHeight: 1.3,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-            }}
-          >
+          <h3 className="text-base font-semibold leading-[1.3] overflow-hidden text-ellipsis [-webkit-line-clamp:2] [-webkit-box-orient:vertical] [display:-webkit-box]">
             {item.title}
-          </Typography>
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{
-              mt: 0.5,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 overflow-hidden text-ellipsis whitespace-nowrap">
             {item.subtitle}
-          </Typography>
+          </p>
           {isSelected ? (
             <Button
               variant="contained"
@@ -178,7 +138,7 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
             </Button>
           )}
         </CardContent>
-      </Box>
+      </div>
     </Card>
   )
 }

--- a/src/components/SearchHistory.tsx
+++ b/src/components/SearchHistory.tsx
@@ -1,7 +1,5 @@
-import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
-import Typography from '@mui/material/Typography'
 import HistoryIcon from '@mui/icons-material/History'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { useSearchHistory } from '../hooks/useSearchHistory'
@@ -23,12 +21,11 @@ export default function SearchHistory({
   }
 
   return (
-    <Box
-      className="mt-4 rounded-xl p-4"
-      sx={{
+    <div
+      className="mt-4 rounded-xl border p-4"
+      style={{
         backgroundColor: 'var(--color-surface)',
-        border: '1px solid',
-        borderColor: 'divider',
+        borderColor: 'var(--color-border)',
       }}
       aria-label="検索履歴"
     >
@@ -38,12 +35,12 @@ export default function SearchHistory({
             fontSize="small"
             sx={{ color: 'var(--color-text-secondary)' }}
           />
-          <Typography
-            variant="subtitle2"
-            sx={{ color: 'var(--color-text-primary)', fontWeight: 600 }}
+          <span
+            className="text-sm font-semibold"
+            style={{ color: 'var(--color-text-primary)' }}
           >
             最近の検索
-          </Typography>
+          </span>
         </div>
         <Button
           variant="text"
@@ -63,21 +60,10 @@ export default function SearchHistory({
             label={keyword}
             size="small"
             clickable
+            className="chip-search-history"
             onClick={() => onSearch(keyword)}
             onDelete={() => removeHistory(keyword)}
             sx={{
-              borderRadius: '8px',
-              backgroundColor:
-                'color-mix(in srgb, var(--color-primary) 8%, transparent)',
-              color: 'var(--color-text-primary)',
-              fontWeight: 500,
-              border: '1px solid',
-              borderColor:
-                'color-mix(in srgb, var(--color-primary) 20%, transparent)',
-              '&:hover': {
-                backgroundColor:
-                  'color-mix(in srgb, var(--color-primary) 16%, transparent)',
-              },
               '& .MuiChip-deleteIcon': {
                 color: 'var(--color-text-secondary)',
                 '&:hover': {
@@ -88,6 +74,6 @@ export default function SearchHistory({
           />
         ))}
       </div>
-    </Box>
+    </div>
   )
 }

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,6 +1,4 @@
 import CircularProgress from '@mui/material/CircularProgress'
-import Typography from '@mui/material/Typography'
-import Box from '@mui/material/Box'
 import ResultCard from './ResultCard'
 import SkeletonCard from './SkeletonCard'
 import ErrorMessage from './ErrorMessage'
@@ -34,9 +32,9 @@ export default function SearchResults({
 
   if (error) {
     return (
-      <Box className="mt-8">
+      <div className="mt-8">
         <ErrorMessage message={error} onRetry={onRetry} />
-      </Box>
+      </div>
     )
   }
 
@@ -95,9 +93,9 @@ export default function SearchResults({
             <SkeletonCard key={`skeleton-${i}`} />
           ))
         : isLoading && (
-            <Box className="col-span-full flex justify-center py-6">
+            <div className="col-span-full flex justify-center py-6">
               <CircularProgress size={32} />
-            </Box>
+            </div>
           )}
 
       {!isLoading && hasMore && (
@@ -109,11 +107,14 @@ export default function SearchResults({
       )}
 
       {!isLoading && !hasMore && results.length > 0 && (
-        <Box className="col-span-full py-4 text-center">
-          <Typography variant="body2" color="text.secondary">
+        <div className="col-span-full py-4 text-center">
+          <p
+            className="text-sm"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
             全件表示しました
-          </Typography>
-        </Box>
+          </p>
+        </div>
       )}
     </div>
   )

--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Collapse from '@mui/material/Collapse'
 import IconButton from '@mui/material/IconButton'
@@ -177,9 +176,9 @@ function MobileCollapsedBar({
         </span>
       </div>
       <ExpandMoreIcon
-        sx={{
+        className="transition-transform duration-300"
+        style={{
           color: 'var(--color-text-secondary)',
-          transition: 'transform 0.3s',
           transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
           fontSize: 22,
         }}
@@ -222,7 +221,7 @@ function SelectionArea({
   }
 
   return (
-    <Box>
+    <div>
       {/* Desktop: always show full view */}
       <div className="hidden sm:block">
         <div className="mb-2 flex items-center justify-between">
@@ -285,21 +284,12 @@ function SelectionArea({
 
       {/* Mobile floating bar: progressive button (only when >= 1 selected) */}
       {selectedCount >= 1 && (
-        <Box
-          sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            zIndex: 1200,
-            display: { xs: 'flex', sm: 'none' },
-            justifyContent: 'center',
-            pb: `max(12px, env(safe-area-inset-bottom))`,
-            pt: 1.5,
-            px: 2,
+        <div
+          className="fixed inset-x-0 bottom-0 z-[1200] flex justify-center px-2 pt-1.5 pointer-events-none sm:hidden"
+          style={{
+            paddingBottom: 'max(12px, env(safe-area-inset-bottom))',
             background:
               'linear-gradient(transparent, rgba(255,255,255,0.95) 30%)',
-            pointerEvents: 'none',
           }}
         >
           <Button
@@ -307,8 +297,8 @@ function SelectionArea({
             onClick={handleCreate}
             disabled={!isComplete}
             size="large"
+            className={`pointer-events-auto ${isComplete ? 'animate-scale-in animate-pulse-soft' : ''}`}
             sx={{
-              pointerEvents: 'auto',
               minHeight: 48,
               minWidth: 200,
               fontSize: '1rem',
@@ -317,9 +307,6 @@ function SelectionArea({
               boxShadow: isComplete
                 ? '0 4px 14px rgba(0,0,0,0.25)'
                 : '0 2px 8px rgba(0,0,0,0.12)',
-              ...(isComplete && {
-                animation: 'scaleIn 0.3s ease-out, pulse-soft 0.4s ease-in-out',
-              }),
               '&:hover': {
                 boxShadow: '0 6px 20px rgba(0,0,0,0.3)',
               },
@@ -334,9 +321,9 @@ function SelectionArea({
               </span>
             )}
           </Button>
-        </Box>
+        </div>
       )}
-    </Box>
+    </div>
   )
 }
 

--- a/src/components/SkeletonCard.tsx
+++ b/src/components/SkeletonCard.tsx
@@ -1,6 +1,5 @@
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 
 /**
@@ -10,9 +9,8 @@ import Skeleton from '@mui/material/Skeleton'
 export default function SkeletonCard() {
   return (
     <Card
+      className="flex border-l-4"
       sx={{
-        display: 'flex',
-        borderLeft: '4px solid',
         borderLeftColor: 'action.disabled',
       }}
     >
@@ -25,14 +23,7 @@ export default function SkeletonCard() {
           flexShrink: 0,
         }}
       />
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minWidth: 0,
-        }}
-      >
+      <div className="flex flex-col flex-1 min-w-0">
         <CardContent sx={{ flex: 1, py: 1.5, '&:last-child': { pb: 1.5 } }}>
           {/* Title */}
           <Skeleton variant="text" width="80%" height={24} />
@@ -41,7 +32,7 @@ export default function SkeletonCard() {
           {/* Button */}
           <Skeleton variant="rounded" width={100} height={30} sx={{ mt: 1 }} />
         </CardContent>
-      </Box>
+      </div>
     </Card>
   )
 }

--- a/src/components/ThemeHistory.tsx
+++ b/src/components/ThemeHistory.tsx
@@ -1,7 +1,5 @@
-import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
-import Typography from '@mui/material/Typography'
 import { useThemeHistory } from '../hooks/useThemeHistory'
 
 type ThemeHistoryProps = {
@@ -16,18 +14,18 @@ export default function ThemeHistory({ onSelect }: ThemeHistoryProps) {
   }
 
   return (
-    <Box
+    <div
       className="mt-2 rounded-lg p-3"
-      sx={{ backgroundColor: 'var(--color-surface)' }}
+      style={{ backgroundColor: 'var(--color-surface)' }}
       aria-label="テーマ履歴"
     >
       <div className="mb-2 flex items-center justify-between">
-        <Typography
-          variant="subtitle2"
-          sx={{ color: 'var(--color-text-primary)' }}
+        <span
+          className="text-sm font-medium"
+          style={{ color: 'var(--color-text-primary)' }}
         >
           最近のテーマ
-        </Typography>
+        </span>
         <Button
           variant="text"
           size="small"
@@ -50,6 +48,6 @@ export default function ThemeHistory({ onSelect }: ThemeHistoryProps) {
           />
         ))}
       </div>
-    </Box>
+    </div>
   )
 }

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import { buildEditUrl } from '../utils/url-params'
 import ErrorMessage from './ErrorMessage'
@@ -110,39 +109,12 @@ export default function Top3Content({ params }: Props) {
         {/* Theme display with decorative quotes via CSS pseudo-elements */}
         {params.theme && (
           <div className="mt-3 text-center">
-            <Typography
-              variant="h6"
-              sx={{
-                color: 'var(--color-text-primary)',
-                display: 'inline-block',
-                px: 3,
-                position: 'relative',
-                '&::before': {
-                  content: '"\\201C"',
-                  position: 'absolute',
-                  left: -4,
-                  top: -8,
-                  fontSize: '2.5rem',
-                  color: 'var(--color-primary)',
-                  opacity: 0.3,
-                  fontFamily: 'Georgia, serif',
-                  lineHeight: 1,
-                },
-                '&::after': {
-                  content: '"\\201D"',
-                  position: 'absolute',
-                  right: -4,
-                  bottom: -12,
-                  fontSize: '2.5rem',
-                  color: 'var(--color-primary)',
-                  opacity: 0.3,
-                  fontFamily: 'Georgia, serif',
-                  lineHeight: 1,
-                },
-              }}
+            <h2
+              className="theme-quote text-xl font-medium"
+              style={{ color: 'var(--color-text-primary)' }}
             >
               {params.theme}
-            </Typography>
+            </h2>
           </div>
         )}
 

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -1,5 +1,4 @@
 import Skeleton from '@mui/material/Skeleton'
-import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import type { SearchResultItem } from '../types/common'
 
@@ -42,9 +41,7 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
   if (error) {
     return (
       <div className="flex min-h-[280px] flex-1 flex-col items-center justify-center rounded-xl border border-red-200 bg-red-50 p-4">
-        <Typography variant="caption" className="text-red-500">
-          {error}
-        </Typography>
+        <span className="text-xs text-red-500">{error}</span>
         {onRetry && (
           <Button
             size="small"
@@ -68,12 +65,12 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
           backgroundColor: 'var(--color-surface)',
         }}
       >
-        <Typography
-          variant="caption"
+        <span
+          className="text-xs"
           style={{ color: 'var(--color-text-secondary)' }}
         >
           {label} - データなし
-        </Typography>
+        </span>
       </div>
     )
   }
@@ -106,17 +103,12 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
             color: categoryColor.text,
           }}
         >
-          <Typography
-            variant="caption"
-            sx={{
-              fontSize: '0.6rem',
-              fontWeight: 700,
-              letterSpacing: '0.1em',
-              color: 'inherit',
-            }}
+          <span
+            className="text-[0.6rem] font-bold tracking-widest"
+            style={{ color: 'inherit' }}
           >
             {label}
-          </Typography>
+          </span>
         </div>
 
         {/* Rank badge overlapping image top */}
@@ -130,17 +122,12 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
               boxShadow: '0 2px 8px rgba(245, 158, 11, 0.4)',
             }}
           >
-            <Typography
-              variant="caption"
-              sx={{
-                fontSize: '0.8rem',
-                fontWeight: 800,
-                color: '#78350f',
-                lineHeight: 1,
-              }}
+            <span
+              className="text-[0.8rem] font-extrabold leading-none"
+              style={{ color: '#78350f' }}
             >
               #1
-            </Typography>
+            </span>
           </div>
         </div>
 
@@ -155,24 +142,15 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
             }
           }}
         />
-        <Typography
-          variant="body2"
-          className="text-center font-semibold"
-          sx={{ fontSize: '0.85rem', lineHeight: 1.3 }}
-        >
+        <p className="text-center text-[0.85rem] font-semibold leading-tight">
           {work.title}
-        </Typography>
-        <Typography
-          variant="caption"
-          className="text-center"
-          sx={{
-            fontSize: '0.7rem',
-            color: 'var(--color-text-secondary)',
-            mt: 0.25,
-          }}
+        </p>
+        <span
+          className="mt-1 text-center text-[0.7rem]"
+          style={{ color: 'var(--color-text-secondary)' }}
         >
           {work.subtitle}
-        </Typography>
+        </span>
         {work.externalUrl && (
           <a
             href={work.externalUrl}

--- a/src/index.css
+++ b/src/index.css
@@ -175,3 +175,51 @@ body {
     animation: none !important;
   }
 }
+
+/* ========================================
+   Search History Chip & Theme Quote Styles
+   ======================================== */
+
+.chip-search-history {
+  border-radius: 8px;
+  background-color: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  color: var(--color-text-primary);
+  font-weight: 500;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 20%, transparent);
+  transition: background-color 0.2s ease;
+}
+
+.chip-search-history:hover {
+  background-color: color-mix(in srgb, var(--color-primary) 16%, transparent);
+}
+
+.theme-quote {
+  position: relative;
+  display: inline-block;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.theme-quote::before {
+  content: '\201C';
+  position: absolute;
+  left: -4px;
+  top: -8px;
+  font-size: 2.5rem;
+  color: var(--color-primary);
+  opacity: 0.3;
+  font-family: Georgia, serif;
+  line-height: 1;
+}
+
+.theme-quote::after {
+  content: '\201D';
+  position: absolute;
+  right: -4px;
+  bottom: -12px;
+  font-size: 2.5rem;
+  color: var(--color-primary);
+  opacity: 0.3;
+  font-family: Georgia, serif;
+  line-height: 1;
+}


### PR DESCRIPTION
## 概要

`CLAUDE.md` のスタイリングガイドラインに違反している8ファイルを修正。

## 変更内容

### MUI Box → `<div>` + Tailwind
- `ResultCard.tsx`
- `SearchHistory.tsx`
- `SelectionArea.tsx`
- `SkeletonCard.tsx`
- `SearchResults.tsx`
- `ThemeHistory.tsx`

### MUI Typography → HTML要素 + Tailwind
- `ResultCard.tsx`: `Typography` → `<h3>`, `<p>`
- `SearchHistory.tsx`: `Typography` → `<span>`
- `WorkCard.tsx`: `Typography` → `<span>`, `<p>`
- `Top3Content.tsx`: `Typography` → `<h2>` + `.theme-quote` CSSクラス
- `SearchResults.tsx`: `Typography` → `<p>`
- `ThemeHistory.tsx`: `Typography` → `<span>`

### MUI sx → Tailwind / style / CSSクラス
- `ResultCard.tsx`: `cursor`, `opacity`, `display: flex` 等を `className` へ
- `SearchHistory.tsx`: `color-mix()` を `.chip-search-history` CSSクラスへ
- `SelectionArea.tsx`: レスポンシブ表示切替を Tailwind `sm:hidden` に統一、`Box` の `sx` を `div` + Tailwind へ
- `SkeletonCard.tsx`: `borderLeft` を Tailwind `border-l-4` へ

### CSS追加 (`src/index.css`)
- `.chip-search-history`: 検索履歴Chip用スタイル（`color-mix()` を活用）
- `.theme-quote`: テーマ表示の装飾引用符（`::before`/`::after`擬似要素）

## 方針
- `sx` は MUI 内部構造（`& .MuiXxx-root`）や MUI テーマ参照（`primary.main`, `action.disabled`）のみに限定
- レイアウト・装飾は Tailwind CSS + CSS custom properties
- MUI の機能コンポーネント（Button, Card, Chip, Skeleton 等）は維持

## チェック結果
- ✅ `npm run lint`
- ✅ `npm run format:check`
- ✅ `npm run typecheck`
- ✅ `npm run test` (421 tests passed)

Closes #174