### PR TITLE
fix: シェアボタンのユーザージェスチャータイムアウト問題を修正

### DIFF
--- a/src/components/ShareButtons.test.tsx
+++ b/src/components/ShareButtons.test.tsx
@@ -11,7 +11,12 @@ vi.mock('../utils/image-helpers', async (importOriginal) => {
   }
 })
 
+vi.mock('../utils/share-url', () => ({
+  createShortUrl: vi.fn(),
+}))
+
 import { generateImageBlob } from '../utils/image-helpers'
+import { createShortUrl } from '../utils/share-url'
 
 describe('ShareButtons', () => {
   let originalClipboard: Clipboard
@@ -327,6 +332,107 @@ describe('ShareButtons', () => {
             'シェアに失敗しました。URLをコピーして手動でシェアしてください。',
           ),
         ).toBeInTheDocument()
+      })
+    })
+
+    it('retries with text-only share when image share fails with NotAllowedError', async () => {
+      const preBlob = new Blob(['pre-generated'], { type: 'image/png' })
+      const shareMock = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new DOMException('not allowed', 'NotAllowedError'),
+        )
+        .mockResolvedValueOnce(undefined)
+      const canShareMock = vi.fn().mockReturnValue(true)
+      Object.assign(navigator, { share: shareMock, canShare: canShareMock })
+
+      const mockCaptureRef = {
+        current: document.createElement('div'),
+      } as RefObject<HTMLDivElement>
+
+      render(
+        <ShareButtons
+          theme="テスト"
+          captureRef={mockCaptureRef}
+          preGeneratedBlob={preBlob}
+        />,
+      )
+      fireEvent.click(screen.getByLabelText('シェア'))
+
+      await waitFor(() => {
+        expect(shareMock).toHaveBeenCalledTimes(2)
+        expect(shareMock).toHaveBeenLastCalledWith({
+          title: 'My No.1s',
+          text: `「テスト」 #MyNo1s\n${window.location.href}`,
+          url: window.location.href,
+        })
+      })
+    })
+  })
+
+  describe('Short URL pre-resolution', () => {
+    it('pre-resolves short URL on mount when shareParams are provided', async () => {
+      vi.mocked(createShortUrl).mockResolvedValue('/s/abc123')
+      const shareMock = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { share: shareMock })
+
+      const shareParams = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: 'm1',
+        movieId: 'mv1',
+      }
+
+      render(<ShareButtons theme="テスト" shareParams={shareParams} />)
+
+      // Wait for pre-resolution to complete
+      await waitFor(() => {
+        expect(createShortUrl).toHaveBeenCalledWith(shareParams)
+      })
+
+      // Now click share — should use the pre-resolved URL, not call createShortUrl again
+      fireEvent.click(screen.getByLabelText('シェア'))
+
+      await waitFor(() => {
+        expect(shareMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            text: `「テスト」 #MyNo1s\n${window.location.origin}/s/abc123`,
+            url: `${window.location.origin}/s/abc123`,
+          }),
+        )
+      })
+
+      // createShortUrl should only have been called once (on mount), not again on share
+      expect(createShortUrl).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to current URL when pre-resolution fails', async () => {
+      vi.mocked(createShortUrl).mockRejectedValue(new Error('network error'))
+      const shareMock = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { share: shareMock })
+
+      const shareParams = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: 'm1',
+        movieId: 'mv1',
+      }
+
+      render(<ShareButtons theme="テスト" shareParams={shareParams} />)
+
+      // Wait for the failed pre-resolution attempt
+      await waitFor(() => {
+        expect(createShortUrl).toHaveBeenCalled()
+      })
+
+      fireEvent.click(screen.getByLabelText('シェア'))
+
+      await waitFor(() => {
+        expect(shareMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: window.location.href,
+          }),
+        )
       })
     })
   })

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, type RefObject } from 'react'
+import { useState, useCallback, useEffect, useRef, type RefObject } from 'react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import Snackbar from '@mui/material/Snackbar'
@@ -38,34 +38,41 @@ export default function ShareButtons({
   const [copyFailed, setCopyFailed] = useState(false)
   const [shareFailed, setShareFailed] = useState(false)
   const [shareGenerating, setShareGenerating] = useState(false)
-  const [cachedShortUrl, setCachedShortUrl] = useState<string | null>(null)
+  const resolvedUrlRef = useRef<string | null>(null)
 
   const handleCloseSuccess = useCallback(() => setCopied(false), [])
   const handleCloseError = useCallback(() => setCopyFailed(false), [])
   const handleCloseShareError = useCallback(() => setShareFailed(false), [])
 
-  const resolveShareUrl = useCallback(async (): Promise<string> => {
-    if (cachedShortUrl) return cachedShortUrl
-    if (!shareParams) return window.location.href
-    try {
-      const shortPath = await createShortUrl(shareParams)
-      const fullUrl = `${window.location.origin}${shortPath}`
-      setCachedShortUrl(fullUrl)
-      return fullUrl
-    } catch {
-      // Fallback to current URL if short URL creation fails
-      return window.location.href
+  // Pre-resolve short URL on mount so it's ready when user taps share
+  useEffect(() => {
+    if (!shareParams) return
+    let cancelled = false
+    createShortUrl(shareParams)
+      .then((shortPath) => {
+        if (!cancelled) {
+          resolvedUrlRef.current = `${window.location.origin}${shortPath}`
+        }
+      })
+      .catch(() => {
+        // Fallback: will use window.location.href
+      })
+    return () => {
+      cancelled = true
     }
-  }, [shareParams, cachedShortUrl])
+  }, [shareParams])
+
+  const getShareUrl = useCallback((): string => {
+    return resolvedUrlRef.current ?? window.location.href
+  }, [])
 
   const handleCopyUrl = useCallback(async () => {
+    const url = getShareUrl()
     try {
-      const url = await resolveShareUrl()
       await navigator.clipboard.writeText(url)
       setCopied(true)
     } catch (error) {
       console.warn('Clipboard API failed, attempting fallback:', error)
-      const url = cachedShortUrl ?? window.location.href
       const textarea = document.createElement('textarea')
       textarea.value = url
       textarea.style.position = 'fixed'
@@ -85,12 +92,12 @@ export default function ShareButtons({
         document.body.removeChild(textarea)
       }
     }
-  }, [resolveShareUrl, cachedShortUrl])
+  }, [getShareUrl])
 
   const handleWebShare = useCallback(async () => {
     setShareGenerating(true)
     try {
-      const shareUrl = await resolveShareUrl()
+      const shareUrl = getShareUrl()
 
       // Try to share with image if captureRef is available and canShare supports files
       if (captureRef?.current) {
@@ -102,12 +109,24 @@ export default function ShareButtons({
           typeof navigator.canShare === 'function' &&
           navigator.canShare({ files: [file] })
         ) {
-          await navigator.share({
-            text: buildShareText(theme, shareUrl),
-            url: shareUrl,
-            files: [file],
-          })
-          return
+          try {
+            await navigator.share({
+              text: buildShareText(theme, shareUrl),
+              url: shareUrl,
+              files: [file],
+            })
+            return
+          } catch (fileShareError) {
+            // If image share was rejected (e.g. NotAllowedError due to gesture timeout),
+            // retry with text-only share below
+            if (
+              fileShareError instanceof DOMException &&
+              fileShareError.name === 'AbortError'
+            ) {
+              return
+            }
+            // Fall through to text-only share
+          }
         }
       }
 
@@ -126,7 +145,7 @@ export default function ShareButtons({
     } finally {
       setShareGenerating(false)
     }
-  }, [captureRef, theme, preGeneratedBlob, resolveShareUrl])
+  }, [captureRef, theme, preGeneratedBlob, getShareUrl])
 
   const canWebShare =
     typeof navigator !== 'undefined' && typeof navigator.share === 'function'


### PR DESCRIPTION
## 問題
シェアボタンをタップしても「たまに」シェアに失敗する。

## 原因
`handleWebShare` 内で以下の非同期チェーンが走り、`navigator.share()` 呼び出し時にブラウザのユーザージェスチャー制限（数秒）を超過していた:

1. `resolveShareUrl()` → **fetch で短縮URL作成** (ネットワーク遅延)
2. `generateImageBlob()` → html2canvas でDOM→Canvas変換 (CPU負荷)
3. `navigator.share()` → ← ここでジェスチャー期限切れ → **NotAllowedError**

## 修正内容

### 1. 短縮URLの事前取得
- コンポーネントマウント時に `useEffect` で短縮URLを事前に取得し `ref` にキャッシュ
- シェアボタンタップ時は同期的に `ref` から取得（fetch 待ちゼロ）
- 事前取得が間に合わない/失敗した場合は `window.location.href` にフォールバック

### 2. 画像付きシェア失敗時のテキストフォールバック
- 画像付き `navigator.share({ files })" が `NotAllowedError` 等で失敗した場合
- テキスト+URLのみで自動リトライ（ユーザーにエラーを見せない）
- `AbortError`（ユーザーがキャンセル）の場合はリトライしない

## テスト
- 短縮URL事前取得のテスト追加（正常系・失敗系）
- 画像シェア失敗→テキストリトライのテスト追加
- 既存テスト全21件 + 新規3件 = 全24件パス