### PR TITLE
fix: mbidなしアルバムのフォールバックIDをURL-safe Base64形式に変更

### DIFF
--- a/src/services/lastfm.test.ts
+++ b/src/services/lastfm.test.ts
@@ -236,4 +236,55 @@ describe('getMusicById', () => {
     const result = await getMusicById('api-key', 'invalid-mbid')
     expect(result.ok).toBe(false)
   })
+
+  it('generates URL-safe fallback id (no =, +, /)', async () => {
+    const { encodeFallbackId } = await import('./lastfm')
+    const id = encodeFallbackId('summer', 'Raph')
+    expect(id).toMatch(/^lastfm-[\w-]+$/)
+    expect(id).not.toContain('=')
+    expect(id).not.toContain('+')
+    expect(id).not.toContain('/')
+  })
+
+  it('resolves fallback id (lastfm- prefix) using artist+album params', async () => {
+    server.use(
+      http.get(LASTFM_BASE, ({ request }) => {
+        const url = new URL(request.url)
+        expect(url.searchParams.get('method')).toBe('album.getinfo')
+        expect(url.searchParams.get('artist')).toBe('Raph')
+        expect(url.searchParams.get('album')).toBe('summer')
+        expect(url.searchParams.has('mbid')).toBe(false)
+        return HttpResponse.json(
+          mockAlbumInfoResponse({ name: 'summer', artist: 'Raph' }),
+        )
+      }),
+    )
+    const { getMusicById, encodeFallbackId } = await import('./lastfm')
+    const fallbackId = encodeFallbackId('summer', 'Raph')
+    const result = await getMusicById('api-key', fallbackId)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.title).toBe('summer')
+      expect(result.data.subtitle).toBe('Raph')
+    }
+  })
+
+  it('search uses encodeFallbackId for albums without mbid', async () => {
+    server.use(
+      http.get(LASTFM_BASE, () =>
+        HttpResponse.json(
+          mockAlbumSearchResponse([
+            mockAlbum({ mbid: '', name: 'summer', artist: 'Raph' }),
+          ]),
+        ),
+      ),
+    )
+    const { searchMusic, encodeFallbackId } = await import('./lastfm')
+    const result = await searchMusic('api-key', 'test')
+    if (result.ok && result.data.items.length > 0) {
+      const expectedId = encodeFallbackId('summer', 'Raph')
+      expect(result.data.items[0].id).toBe(expectedId)
+      expect(result.data.items[0].id).toMatch(/^lastfm-/)
+    }
+  })
 })

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -149,12 +149,18 @@ export async function getMusicById(
     }
   }
 
+  const fallback = decodeFallbackId(mbid)
   const params = new URLSearchParams({
     method: 'album.getinfo',
-    mbid,
     api_key: apiKey,
     format: 'json',
   })
+  if (fallback) {
+    params.set('artist', fallback.artist)
+    params.set('album', fallback.album)
+  } else {
+    params.set('mbid', mbid)
+  }
 
   const result = await fetchJson<LastfmAlbumInfo>(
     `${BASE_URL}?${params.toString()}`,
@@ -183,7 +189,7 @@ export async function getMusicById(
 // ── Mapping ─────────────────────────────────────────────────────────
 
 function mapSearchAlbumToResult(album: LastfmAlbumSearch): SearchResultItem {
-  const id = album.mbid || generateFallbackId(album.name, album.artist)
+  const id = album.mbid || encodeFallbackId(album.name, album.artist)
   return {
     id,
     category: 'music',
@@ -205,12 +211,40 @@ function getBestImage(images: LastfmImage[]): string {
   return ''
 }
 
-function generateFallbackId(name: string, artist: string): string {
-  const raw = `${artist}::${name}`
-  // Simple hash for uniqueness
-  let hash = 0
-  for (let i = 0; i < raw.length; i++) {
-    hash = (hash * 31 + raw.charCodeAt(i)) | 0
+const FALLBACK_PREFIX = 'lastfm-'
+const FALLBACK_SEPARATOR = '::'
+
+/** URL-safe Base64 encode (no padding, +→-, /→_) */
+function toBase64Url(str: string): string {
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** URL-safe Base64 decode */
+function fromBase64Url(str: string): string {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = (4 - (padded.length % 4)) % 4
+  return atob(padded + '='.repeat(pad))
+}
+
+export function encodeFallbackId(name: string, artist: string): string {
+  const raw = `${artist}${FALLBACK_SEPARATOR}${name}`
+  return `${FALLBACK_PREFIX}${toBase64Url(encodeURIComponent(raw))}`
+}
+
+function decodeFallbackId(
+  id: string,
+): { artist: string; album: string } | null {
+  if (!id.startsWith(FALLBACK_PREFIX)) return null
+  try {
+    const encoded = id.slice(FALLBACK_PREFIX.length)
+    const raw = decodeURIComponent(fromBase64Url(encoded))
+    const sepIndex = raw.indexOf(FALLBACK_SEPARATOR)
+    if (sepIndex === -1) return null
+    return {
+      artist: raw.slice(0, sepIndex),
+      album: raw.slice(sepIndex + FALLBACK_SEPARATOR.length),
+    }
+  } catch {
+    return null
   }
-  return `lastfm-${Math.abs(hash).toString(36)}`
 }


### PR DESCRIPTION
## 問題

Last.fm検索結果でMusicBrainz ID(mbid)が空のアルバムに対して、従来はハッシュベースのID(`lastfm-XXXXX`)を生成していた。このハッシュからアーティスト名・アルバム名を復元できないため、`album.getinfo` APIで取得できず、シェアURLで音楽カードが「データなし」になっていた。

## 原因

- `generateFallbackId()`: `artist::name` の単方向ハッシュを生成（復元不可）
- `getMusicById()`: フォールバックIDをそのまま `mbid` パラメータとしてLast.fm APIに渡していた
- Last.fm APIに存在しないmbidのため404

## 修正内容

- `encodeFallbackId()`: `artist::name` をURL-safe Base64でエンコード（`sanitizeId`の `/^[\w-]+$/` と互換）
- `decodeFallbackId()`: `lastfm-` プレフィックスのIDをデコードしてartist/albumを復元
- `getMusicById()`: フォールバックIDの場合は `mbid` ではなく `artist` + `album` パラメータで `album.getinfo` を呼び出す

## テスト

- URL-safe Base64 IDに `=`, `+`, `/` が含まれないことを検証
- フォールバックIDでの `getMusicById` が artist+album パラメータで取得できることを検証
- 検索結果のmbidなしアルバムに encodeFallbackId が使われることを検証
- 全427テスト通過