### PR TITLE
fix: CORS に POST を許可し、短縮URL生成を冪等化

### DIFF
--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -56,7 +56,22 @@ describe('CORS middleware', () => {
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
       'https://myno1s.exe.xyz:8000',
     )
-    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,POST')
+  })
+
+  it('allows POST in preflight for /api/shares', async () => {
+    const app = await getApp()
+    const req = new Request('http://localhost/api/shares', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://myno1s.exe.xyz:8000',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type',
+      },
+    })
+    const res = await app.request(req)
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST')
   })
 
   it('does not return CORS headers for disallowed origin', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,7 +36,7 @@ app.use(
   '/api/*',
   cors({
     origin: corsOrigins,
-    allowMethods: ['GET'],
+    allowMethods: ['GET', 'POST'],
   }),
 )
 

--- a/src/server/share-store.test.ts
+++ b/src/server/share-store.test.ts
@@ -98,6 +98,32 @@ describe('share-store', () => {
     })
   })
 
+  describe('idempotency', () => {
+    it('returns the same id for identical params', () => {
+      const store = createShareStore(dbPath)
+      const id1 = store.save(sampleParams)
+      const id2 = store.save(sampleParams)
+      expect(id1).toBe(id2)
+      store.close()
+    })
+
+    it('returns different ids for different params', () => {
+      const store = createShareStore(dbPath)
+      const id1 = store.save(sampleParams)
+      const id2 = store.save({ ...sampleParams, theme: '別のテーマ' })
+      expect(id1).not.toBe(id2)
+      store.close()
+    })
+
+    it('returns different ids when only one field differs', () => {
+      const store = createShareStore(dbPath)
+      const id1 = store.save(sampleParams)
+      const id2 = store.save({ ...sampleParams, bookId: 'different' })
+      expect(id1).not.toBe(id2)
+      store.close()
+    })
+  })
+
   describe('input validation', () => {
     it('rejects bookId exceeding max length', () => {
       const store = createShareStore(dbPath)

--- a/src/server/share-store.ts
+++ b/src/server/share-store.ts
@@ -27,6 +27,16 @@ function generateId(): string {
   return crypto.randomBytes(6).toString('base64url')
 }
 
+function computeParamsHash(params: ShareParams): string {
+  const payload = [
+    params.theme,
+    params.bookId,
+    params.musicId,
+    params.movieId,
+  ].join('\0')
+  return crypto.createHash('sha256').update(payload).digest('base64url')
+}
+
 function validateField(name: string, value: string, maxLen: number): void {
   if (value.length > maxLen) {
     throw new Error(`${name} exceeds maximum length of ${maxLen}`)
@@ -71,18 +81,38 @@ export function createShareStore(
       book_id TEXT NOT NULL DEFAULT '',
       music_id TEXT NOT NULL DEFAULT '',
       movie_id TEXT NOT NULL DEFAULT '',
+      params_hash TEXT NOT NULL DEFAULT '',
       created_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
     CREATE INDEX IF NOT EXISTS idx_shares_created_at ON shares(created_at);
   `)
 
+  // Migration: add params_hash column if missing (existing DBs before this change)
+  const columns = db.prepare("PRAGMA table_info('shares')").all() as {
+    name: string
+  }[]
+  if (!columns.some((c) => c.name === 'params_hash')) {
+    db.exec(
+      "ALTER TABLE shares ADD COLUMN params_hash TEXT NOT NULL DEFAULT ''",
+    )
+  }
+
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_shares_params_hash
+      ON shares(params_hash) WHERE params_hash != '';
+  `)
+
   const insertStmt = db.prepare(`
-    INSERT INTO shares (id, theme, book_id, music_id, movie_id, created_at)
-    VALUES (?, ?, ?, ?, ?, unixepoch())
+    INSERT INTO shares (id, theme, book_id, music_id, movie_id, params_hash, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, unixepoch())
   `)
 
   const selectStmt = db.prepare(`
     SELECT theme, book_id, music_id, movie_id FROM shares WHERE id = ?
+  `)
+
+  const selectByHashStmt = db.prepare(`
+    SELECT id FROM shares WHERE params_hash = ?
   `)
 
   const countStmt = db.prepare(`SELECT COUNT(*) as cnt FROM shares`)
@@ -94,6 +124,14 @@ export function createShareStore(
   `)
 
   const saveTransaction = db.transaction((params: ShareParams): string => {
+    const hash = computeParamsHash(params)
+
+    // Return existing ID if the same params were already saved
+    const existing = selectByHashStmt.get(hash) as { id: string } | undefined
+    if (existing) {
+      return existing.id
+    }
+
     let id = generateId()
     // Ensure uniqueness (extremely unlikely collision but safe)
     while (selectStmt.get(id)) {
@@ -113,6 +151,7 @@ export function createShareStore(
       params.bookId,
       params.musicId,
       params.movieId,
+      hash,
     )
     return id
   })


### PR DESCRIPTION
## 問題

共有時の短縮URLが機能していなかった。

### 原因1: CORS の allowMethods に POST が含まれていない
`/api/shares` への POST リクエストが CORS preflight で拒否されていた。
本番環境では同一オリジンのため影響が少ないが、開発環境やクロスオリジンアクセスでは POST が拒否される。

### 原因2: 短縮URLの冪等性がない
同じパラメータで何度も POST すると毎回新しい ID が生成され、DB が不必要に膨らんでいた。

## 修正内容

1. **CORS の `allowMethods` に `POST` を追加** (`src/server/index.ts`)
2. **share-store に冪等性を追加** (`src/server/share-store.ts`)
   - `params_hash` カラム（SHA-256）を追加し、同じパラメータの場合は既存 ID を返す
   - 既存 DB のマイグレーション対応（`params_hash` カラムの自動追加）

## テスト

- CORS テスト: POST preflight が許可されることを確認
- share-store テスト: 冪等性（同一パラメータ→同一ID）を確認
- 全431テストパス