### PR TITLE
fix: isValidBody の型ガード強化 & 外部APIバリデーションのネスト検証追加

### DIFF
--- a/src/server/routes/shares.test.ts
+++ b/src/server/routes/shares.test.ts
@@ -46,6 +46,21 @@ describe('shares route', () => {
       expect(res.status).toBe(400)
     })
 
+    it('returns 400 when body is an array', async () => {
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify([{ bookId: 'abc' }]),
+      })
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as {
+        ok: boolean
+        error: { message: string }
+      }
+      expect(json.ok).toBe(false)
+      expect(json.error.message).toBe('Invalid body')
+    })
+
     it('returns 400 for invalid JSON', async () => {
       const res = await app.request('/', {
         method: 'POST',

--- a/src/server/routes/shares.ts
+++ b/src/server/routes/shares.ts
@@ -7,7 +7,7 @@ function isValidBody(body: unknown): body is {
   musicId?: string
   movieId?: string
 } {
-  return typeof body === 'object' && body !== null
+  return typeof body === 'object' && body !== null && !Array.isArray(body)
 }
 
 export function createSharesApp(dbPath: string) {

--- a/src/services/google-books.test.ts
+++ b/src/services/google-books.test.ts
@@ -152,6 +152,32 @@ describe('searchBooks', () => {
     }
   })
 
+  it('returns validation error when items contain invalid entries', async () => {
+    server.use(
+      http.get(BOOKS_API, () =>
+        HttpResponse.json(mockSearchResponse([{ selfLink: 'link' }], 1)),
+      ),
+    )
+    const result = await searchBooks('key', 'test')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/id/)
+    }
+  })
+
+  it('returns validation error when items lack volumeInfo', async () => {
+    server.use(
+      http.get(BOOKS_API, () =>
+        HttpResponse.json(mockSearchResponse([{ id: 'vol-1' }], 1)),
+      ),
+    )
+    const result = await searchBooks('key', 'test')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/volumeInfo/)
+    }
+  })
+
   it('handles missing thumbnails', async () => {
     server.use(
       http.get(BOOKS_API, () =>

--- a/src/services/google-books.ts
+++ b/src/services/google-books.ts
@@ -45,7 +45,19 @@ type GoogleBooksSearchResponse = {
 function validateSearchResponse(data: unknown): GoogleBooksSearchResponse {
   const obj = assertObject(data, 'Google Books API')
   assertField<number>(obj, 'totalItems', 'number', 'Google Books response')
-  assertOptionalArray(obj, 'items', 'Google Books response')
+  const items = assertOptionalArray(obj, 'items', 'Google Books response')
+  if (items) {
+    for (const item of items) {
+      const vol = assertObject(item, 'Google Books volume item')
+      assertField<string>(vol, 'id', 'string', 'Google Books volume item')
+      assertField<object>(
+        vol,
+        'volumeInfo',
+        'object',
+        'Google Books volume item',
+      )
+    }
+  }
   return data as GoogleBooksSearchResponse
 }
 

--- a/src/services/lastfm.test.ts
+++ b/src/services/lastfm.test.ts
@@ -167,6 +167,24 @@ describe('searchMusic', () => {
     }
   })
 
+  it('returns validation error when album items lack name', async () => {
+    server.use(
+      http.get(LASTFM_BASE, () =>
+        HttpResponse.json(
+          mockAlbumSearchResponse([
+            { artist: 'Test', mbid: '', url: '', image: [] },
+          ]),
+        ),
+      ),
+    )
+    const { searchMusic } = await import('./lastfm')
+    const result = await searchMusic('api-key', 'test')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/name/)
+    }
+  })
+
   it('filters out albums with no images', async () => {
     server.use(
       http.get(LASTFM_BASE, () =>

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -4,7 +4,7 @@ import type {
   SearchResultItem,
 } from '../types/common.ts'
 import { fetchJson } from '../utils/fetch-client.ts'
-import { assertObject, assertField } from './validation-helpers.ts'
+import { assertObject, assertField, assertArray } from './validation-helpers.ts'
 
 const BASE_URL = 'https://ws.audioscrobbler.com/2.0'
 const DEFAULT_MAX_RESULTS = 20
@@ -53,13 +53,22 @@ type LastfmErrorResponse = {
 function validateSearchResponse(data: unknown): LastfmSearchResponse {
   const obj = assertObject(data, 'Last.fm search API')
   assertField<object>(obj, 'results', 'object', 'Last.fm search response')
-  const results = obj['results'] as Record<string, unknown>
+  const results = assertObject(obj['results'], 'Last.fm search results')
   assertField<object>(
     results,
     'albummatches',
     'object',
     'Last.fm search results',
   )
+  const albummatches = assertObject(
+    results['albummatches'],
+    'Last.fm albummatches',
+  )
+  const albums = assertArray(albummatches, 'album', 'Last.fm albummatches')
+  for (const item of albums) {
+    const album = assertObject(item, 'Last.fm album item')
+    assertField<string>(album, 'name', 'string', 'Last.fm album item')
+  }
   return data as LastfmSearchResponse
 }
 

--- a/src/services/tmdb.test.ts
+++ b/src/services/tmdb.test.ts
@@ -128,6 +128,42 @@ describe('searchMovies', () => {
       expect(result.data.items[1].subtitle).toBe('2024')
     }
   })
+
+  it('returns validation error when results contain invalid items', async () => {
+    server.use(
+      http.get(`${BASE_URL}/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ title: 'No ID Movie' }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    )
+    const result = await searchMovies('key', 'test')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/id/)
+    }
+  })
+
+  it('returns validation error when results items lack title', async () => {
+    server.use(
+      http.get(`${BASE_URL}/search/movie`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [{ id: 1 }],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    )
+    const result = await searchMovies('key', 'test')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/title/)
+    }
+  })
 })
 
 describe('getMovieById', () => {

--- a/src/services/tmdb.ts
+++ b/src/services/tmdb.ts
@@ -56,7 +56,12 @@ function validateSearchResponse(data: unknown): TMDbSearchResponse {
   const obj = assertObject(data, 'TMDb search API')
   assertField<number>(obj, 'total_results', 'number', 'TMDb search response')
   assertField<number>(obj, 'page', 'number', 'TMDb search response')
-  assertArray(obj, 'results', 'TMDb search response')
+  const results = assertArray(obj, 'results', 'TMDb search response')
+  for (const item of results) {
+    const movie = assertObject(item, 'TMDb search result item')
+    assertField<number>(movie, 'id', 'number', 'TMDb search result item')
+    assertField<string>(movie, 'title', 'string', 'TMDb search result item')
+  }
   return data as TMDbSearchResponse
 }
 

--- a/src/services/validation-helpers.test.ts
+++ b/src/services/validation-helpers.test.ts
@@ -21,6 +21,12 @@ describe('assertObject', () => {
   it('throws for undefined', () => {
     expect(() => assertObject(undefined, 'test')).toThrow('Expected object')
   })
+  it('throws for array', () => {
+    expect(() => assertObject([1, 2, 3], 'test')).toThrow('Expected object')
+  })
+  it('throws for empty array', () => {
+    expect(() => assertObject([], 'test')).toThrow('Expected object')
+  })
 })
 
 describe('assertField', () => {

--- a/src/services/validation-helpers.ts
+++ b/src/services/validation-helpers.ts
@@ -2,7 +2,7 @@ export function assertObject(
   data: unknown,
   label: string,
 ): Record<string, unknown> {
-  if (typeof data !== 'object' || data === null) {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
     throw new Error(`Expected object response from ${label}`)
   }
   return data as Record<string, unknown>


### PR DESCRIPTION
## 概要

#176 に対応。サーバーサイドの入力バリデーションの型安全性を強化。

## 変更内容

### 1. `assertObject` の Array 排除
- `Array.isArray(data)` チェックを追加し、配列がオブジェクトとして通過する問題を修正

### 2. `isValidBody` の Array 排除
- `shares.ts` の `isValidBody` に `!Array.isArray(body)` を追加

### 3. TMDb バリデーション強化
- `validateSearchResponse` で `results[]` 各要素の `id`(number), `title`(string) を検証

### 4. Last.fm バリデーション強化
- `validateSearchResponse` で `album[]` 各要素の `name`(string) を検証

### 5. Google Books バリデーション強化
- `validateSearchResponse` で `items[]` 各要素の `id`(string), `volumeInfo`(object) を検証

## テスト
- 全変更に対応するテストケースを追加（計8テスト追加）
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (439 tests passed)

Closes #176