### PR TITLE
feat: レイアウトセレクターをToggleButtonGroupにリデザイン (#133)

### DIFF
--- a/src/components/LayoutSelector.test.tsx
+++ b/src/components/LayoutSelector.test.tsx
@@ -16,11 +16,11 @@ describe('LayoutSelector', () => {
     expect(screen.getByTestId('layout-selector')).toBeInTheDocument()
   })
 
-  it('renders select elements for all three slots', () => {
+  it('renders toggle button groups for all three slots', () => {
     render(<LayoutSelector layout={defaultLayout} onLayoutChange={vi.fn()} />)
-    expect(screen.getByTestId('select-top')).toBeInTheDocument()
-    expect(screen.getByTestId('select-bottom-left')).toBeInTheDocument()
-    expect(screen.getByTestId('select-bottom-right')).toBeInTheDocument()
+    expect(screen.getByTestId('layout-slot-top')).toBeInTheDocument()
+    expect(screen.getByTestId('layout-slot-bottom-left')).toBeInTheDocument()
+    expect(screen.getByTestId('layout-slot-bottom-right')).toBeInTheDocument()
   })
 
   it('displays Japanese slot labels', () => {
@@ -30,21 +30,44 @@ describe('LayoutSelector', () => {
     expect(screen.getByText('右下:')).toBeInTheDocument()
   })
 
-  it('reflects current layout in select values', () => {
+  it('renders category buttons with labels for each slot', () => {
     render(<LayoutSelector layout={defaultLayout} onLayoutChange={vi.fn()} />)
-    expect(screen.getByTestId('select-top')).toHaveValue('music')
-    expect(screen.getByTestId('select-bottom-left')).toHaveValue('book')
-    expect(screen.getByTestId('select-bottom-right')).toHaveValue('movie')
+    // Each slot has 3 category buttons → 9 total
+    const bookButtons = screen.getAllByText('BOOK')
+    const musicButtons = screen.getAllByText('MUSIC')
+    const movieButtons = screen.getAllByText('MOVIE')
+    expect(bookButtons).toHaveLength(3)
+    expect(musicButtons).toHaveLength(3)
+    expect(movieButtons).toHaveLength(3)
   })
 
-  it('calls onLayoutChange with slot and category when changed', () => {
+  it('reflects current layout as selected toggle buttons', () => {
+    render(<LayoutSelector layout={defaultLayout} onLayoutChange={vi.fn()} />)
+    // top slot: music is selected
+    const topGroup = screen.getByTestId('layout-slot-top')
+    const topSelected = topGroup.querySelector('[aria-pressed="true"]')
+    expect(topSelected).toHaveTextContent('MUSIC')
+
+    // bottom-left slot: book is selected
+    const blGroup = screen.getByTestId('layout-slot-bottom-left')
+    const blSelected = blGroup.querySelector('[aria-pressed="true"]')
+    expect(blSelected).toHaveTextContent('BOOK')
+
+    // bottom-right slot: movie is selected
+    const brGroup = screen.getByTestId('layout-slot-bottom-right')
+    const brSelected = brGroup.querySelector('[aria-pressed="true"]')
+    expect(brSelected).toHaveTextContent('MOVIE')
+  })
+
+  it('calls onLayoutChange with slot and category when a toggle button is clicked', () => {
     const onLayoutChange = vi.fn()
     render(
       <LayoutSelector layout={defaultLayout} onLayoutChange={onLayoutChange} />,
     )
-    fireEvent.change(screen.getByTestId('select-top'), {
-      target: { value: 'book' },
-    })
+    // Click BOOK in the top slot (top is currently music)
+    const topGroup = screen.getByTestId('layout-slot-top')
+    const bookButton = topGroup.querySelector('[value="book"]') as HTMLElement
+    fireEvent.click(bookButton)
     expect(onLayoutChange).toHaveBeenCalledWith('top', 'book')
   })
 
@@ -54,9 +77,31 @@ describe('LayoutSelector', () => {
     render(
       <LayoutSelector layout={defaultLayout} onLayoutChange={onLayoutChange} />,
     )
-    fireEvent.change(screen.getByTestId('select-bottom-right'), {
-      target: { value: 'music' },
-    })
+    // Click MUSIC in the bottom-right slot (bottom-right is currently movie)
+    const brGroup = screen.getByTestId('layout-slot-bottom-right')
+    const musicButton = brGroup.querySelector('[value="music"]') as HTMLElement
+    fireEvent.click(musicButton)
     expect(onLayoutChange).toHaveBeenCalledWith('bottom-right', 'music')
+  })
+
+  it('does not call onLayoutChange when clicking the already-selected category', () => {
+    const onLayoutChange = vi.fn()
+    render(
+      <LayoutSelector layout={defaultLayout} onLayoutChange={onLayoutChange} />,
+    )
+    // Click MUSIC in top slot (already selected)
+    const topGroup = screen.getByTestId('layout-slot-top')
+    const musicButton = topGroup.querySelector('[value="music"]') as HTMLElement
+    fireEvent.click(musicButton)
+    expect(onLayoutChange).not.toHaveBeenCalled()
+  })
+
+  it('renders color indicators for each category button', () => {
+    render(<LayoutSelector layout={defaultLayout} onLayoutChange={vi.fn()} />)
+    const topGroup = screen.getByTestId('layout-slot-top')
+    const indicators = topGroup.querySelectorAll(
+      '[data-testid="color-indicator"]',
+    )
+    expect(indicators).toHaveLength(3)
   })
 })

--- a/src/components/LayoutSelector.tsx
+++ b/src/components/LayoutSelector.tsx
@@ -1,6 +1,15 @@
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import type { MediaCategory } from '../types/common'
 import type { LayoutConfig, SlotPosition } from '../constants/image-layout'
-import { SLOT_LABELS, SLOT_POSITIONS } from '../constants/image-layout'
+import {
+  SLOT_LABELS,
+  SLOT_POSITIONS,
+  CATEGORY_LABELS,
+  CATEGORY_COLORS,
+} from '../constants/image-layout'
+
+const CATEGORIES: MediaCategory[] = ['book', 'music', 'movie']
 
 type LayoutSelectorProps = {
   layout: LayoutConfig
@@ -14,31 +23,79 @@ export function LayoutSelector({
   return (
     <div
       data-testid="layout-selector"
-      className="mb-4 flex flex-wrap items-center justify-center gap-3"
+      className="mb-4 flex flex-wrap items-center justify-center gap-4"
     >
       {SLOT_POSITIONS.map((slot) => (
-        <label key={slot} className="flex items-center gap-1.5 text-sm">
-          <span style={{ color: 'var(--color-text-secondary)' }}>
+        <div key={slot} className="flex items-center gap-2">
+          <span
+            className="text-xs font-medium"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
             {SLOT_LABELS[slot]}:
           </span>
-          <select
-            data-testid={`select-${slot}`}
+          <ToggleButtonGroup
+            data-testid={`layout-slot-${slot}`}
             value={layout[slot]}
-            onChange={(e) =>
-              onLayoutChange(slot, e.target.value as MediaCategory)
-            }
-            className="rounded border px-2 py-1 text-sm"
-            style={{
-              borderColor: 'var(--color-border)',
-              background: 'var(--color-surface)',
-              color: 'var(--color-text-primary)',
+            exclusive
+            size="small"
+            onChange={(_, value: MediaCategory | null) => {
+              if (value !== null) {
+                onLayoutChange(slot, value)
+              }
+            }}
+            sx={{
+              '& .MuiToggleButton-root': {
+                border: '1px solid var(--color-border)',
+                borderRadius: '9999px',
+                px: 1.5,
+                py: 0.25,
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                letterSpacing: '0.03em',
+                textTransform: 'none',
+                color: 'var(--color-text-secondary)',
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  background: 'rgba(99, 102, 241, 0.06)',
+                },
+                '&.Mui-selected': {
+                  color: 'var(--color-surface)',
+                  borderColor: 'transparent',
+                  '&:hover': {
+                    filter: 'brightness(1.1)',
+                  },
+                },
+              },
+              '& .MuiToggleButtonGroup-grouped': {
+                borderRadius: '9999px !important',
+                mx: 0.25,
+                border: '1px solid var(--color-border) !important',
+                '&.Mui-selected': {
+                  border: '1px solid transparent !important',
+                },
+              },
             }}
           >
-            <option value="book">Book</option>
-            <option value="music">Music</option>
-            <option value="movie">Movie</option>
-          </select>
-        </label>
+            {CATEGORIES.map((category) => (
+              <ToggleButton
+                key={category}
+                value={category}
+                sx={{
+                  '&.Mui-selected': {
+                    backgroundColor: CATEGORY_COLORS[category],
+                  },
+                }}
+              >
+                <span
+                  data-testid="color-indicator"
+                  className="mr-1 inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: CATEGORY_COLORS[category] }}
+                />
+                {CATEGORY_LABELS[category]}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </div>
       ))}
     </div>
   )

--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -173,9 +173,10 @@ describe('Top3Image', () => {
           movie={mockMovie}
         />,
       )
-      expect(screen.getByText('BOOK')).toBeInTheDocument()
-      expect(screen.getByText('MUSIC')).toBeInTheDocument()
-      expect(screen.getByText('MOVIE')).toBeInTheDocument()
+      // Category labels appear in both LayoutSelector toggles and image slots
+      expect(screen.getAllByText('BOOK').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('MUSIC').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('MOVIE').length).toBeGreaterThanOrEqual(1)
     })
 
     it('does not display #1 badges', () => {
@@ -281,9 +282,10 @@ describe('Top3Image', () => {
           movie={mockMovie}
         />,
       )
-      // Click the top slot select and change to book
-      const topSelect = screen.getByTestId('select-top')
-      fireEvent.change(topSelect, { target: { value: 'book' } })
+      // Click the BOOK button in the top slot toggle group
+      const topGroup = screen.getByTestId('layout-slot-top')
+      const bookButton = topGroup.querySelector('[value="book"]') as HTMLElement
+      fireEvent.click(bookButton)
 
       const topSlot = screen.getByTestId('slot-top')
       expect(topSlot).toHaveTextContent('Test Book')
@@ -300,8 +302,9 @@ describe('Top3Image', () => {
       )
       // Default: top=music, bottom-left=book, bottom-right=movie
       // Change top to book → music should go to bottom-left (where book was)
-      const topSelect = screen.getByTestId('select-top')
-      fireEvent.change(topSelect, { target: { value: 'book' } })
+      const topGroup = screen.getByTestId('layout-slot-top')
+      const bookButton = topGroup.querySelector('[value="book"]') as HTMLElement
+      fireEvent.click(bookButton)
 
       const topSlot = screen.getByTestId('slot-top')
       const bottomLeftSlot = screen.getByTestId('slot-bottom-left')


### PR DESCRIPTION
## 概要

レイアウトセレクターのネイティブ `<select>` を MUI `ToggleButtonGroup` に置き換え、視覚的なわかりやすさを向上させました。

Closes #133

## 変更内容

- **LayoutSelector.tsx**: ネイティブ `<select>` → MUI `ToggleButtonGroup` に変更
  - 各カテゴリボタンにカラーインジケーター（丸ドット）を付与
  - 選択中のボタンはカテゴリ色で背景塗りつぶし
  - pill 型（rounded-full）のトグルボタンでモダンなデザインに
- **LayoutSelector.test.tsx**: ToggleButton 操作に対応したテストに更新 + 2件追加
  - 既に選択済みのカテゴリクリック時に `onLayoutChange` が呼ばれないことを検証
  - カラーインジケーターの描画を検証
- **Top3Image.test.tsx**: ToggleButton化によるテキスト重複への対応

## 受け入れ条件

- [x] ネイティブ `<select>` が置き換えられている
- [x] レイアウト変更が視覚的に分かりやすい

## チェック結果

- ✅ `npm run lint` — エラーなし
- ✅ `npm run format:check` — OK
- ✅ `npm run typecheck` — OK
- ✅ `npm run test` — 442 tests passed