### PR TITLE
fix: /s/:id 表示時にシェアが再作成されるバグを修正

### DIFF
--- a/src/components/ShareButtons.test.tsx
+++ b/src/components/ShareButtons.test.tsx
@@ -371,6 +371,43 @@ describe('ShareButtons', () => {
   })
 
   describe('Short URL pre-resolution', () => {
+    it('skips createShortUrl when existingShareId is provided', async () => {
+      vi.mocked(createShortUrl).mockResolvedValue('/s/new123')
+      const shareMock = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { share: shareMock })
+
+      const shareParams = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: 'm1',
+        movieId: 'mv1',
+      }
+
+      render(
+        <ShareButtons
+          theme="テスト"
+          shareParams={shareParams}
+          existingShareId="abc123"
+        />,
+      )
+
+      // Should NOT call createShortUrl at all
+      await waitFor(() => {
+        expect(createShortUrl).not.toHaveBeenCalled()
+      })
+
+      // Click share — should use the existing share URL
+      fireEvent.click(screen.getByLabelText('シェア'))
+
+      await waitFor(() => {
+        expect(shareMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: `${window.location.origin}/s/abc123`,
+          }),
+        )
+      })
+    })
+
     it('pre-resolves short URL on mount when shareParams are provided', async () => {
       vi.mocked(createShortUrl).mockResolvedValue('/s/abc123')
       const shareMock = vi.fn().mockResolvedValue(undefined)

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -24,6 +24,7 @@ type ShareButtonsProps = {
   captureRef?: RefObject<HTMLDivElement | null>
   preGeneratedBlob?: Blob | null
   shareParams?: ShareParams
+  existingShareId?: string
 }
 
 function buildShareText(theme?: string, url?: string): string {
@@ -36,6 +37,7 @@ export default function ShareButtons({
   captureRef,
   preGeneratedBlob,
   shareParams,
+  existingShareId,
 }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false)
   const [copyFailed, setCopyFailed] = useState(false)
@@ -49,6 +51,11 @@ export default function ShareButtons({
 
   // Pre-resolve short URL on mount so it's ready when user taps share
   useEffect(() => {
+    // If we already have a share ID (e.g. viewing from /s/:id), use it directly
+    if (existingShareId) {
+      resolvedUrlRef.current = `${window.location.origin}/s/${existingShareId}`
+      return
+    }
     if (!shareParams) return
     let cancelled = false
     createShortUrl(shareParams)
@@ -63,7 +70,7 @@ export default function ShareButtons({
     return () => {
       cancelled = true
     }
-  }, [shareParams])
+  }, [shareParams, existingShareId])
 
   const getShareUrl = useCallback((): string => {
     return resolvedUrlRef.current ?? window.location.href

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -19,9 +19,10 @@ type Top3Params = {
 
 type Props = {
   params: Top3Params
+  existingShareId?: string
 }
 
-export default function Top3Content({ params }: Props) {
+export default function Top3Content({ params, existingShareId }: Props) {
   const captureRef = useRef<HTMLDivElement>(null)
   const [captureElement, setCaptureElement] = useState<HTMLDivElement | null>(
     null,
@@ -171,6 +172,7 @@ export default function Top3Content({ params }: Props) {
               musicThumb: music.data?.thumbnailUrl ?? '',
               movieThumb: movie.data?.thumbnailUrl ?? '',
             }}
+            existingShareId={existingShareId}
           />
         </div>
 

--- a/src/pages/ShortUrlPage.test.tsx
+++ b/src/pages/ShortUrlPage.test.tsx
@@ -14,12 +14,17 @@ vi.mock('react-router-dom', async () => {
 vi.mock('../components/Top3Content', () => ({
   default: ({
     params,
+    existingShareId,
   }: {
     params: { theme: string; bookId: string; musicId: string; movieId: string }
+    existingShareId?: string
   }) => (
     <div data-testid="top3-content">
       <span>{params.theme}</span>
       <span>{params.bookId}</span>
+      {existingShareId && (
+        <span data-testid="existing-share-id">{existingShareId}</span>
+      )}
     </div>
   ),
 }))
@@ -73,6 +78,28 @@ describe('ShortUrlPage', () => {
     })
     expect(screen.getByText('テスト')).toBeInTheDocument()
     expect(screen.getByText('b1')).toBeInTheDocument()
+  })
+
+  it('passes existingShareId to Top3Content', async () => {
+    mockUseParams.mockReturnValue({ id: 'xyz789' })
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        data: {
+          theme: 'テスト',
+          bookId: 'b1',
+          musicId: 'm1',
+          movieId: 'mv1',
+        },
+      }),
+    })
+    render(<ShortUrlPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('existing-share-id')).toHaveTextContent(
+        'xyz789',
+      )
+    })
   })
 
   it('calls the correct API endpoint', async () => {

--- a/src/pages/ShortUrlPage.tsx
+++ b/src/pages/ShortUrlPage.tsx
@@ -90,7 +90,7 @@ function ShortUrlPage() {
     )
   }
 
-  return <Top3Content params={data} />
+  return <Top3Content params={data} existingShareId={id} />
 }
 
 export default ShortUrlPage


### PR DESCRIPTION
## 問題

ギャラリー（みんなのNo.1s）からシェアページを開くと、`ShareButtons` の `useEffect` が毎回 `POST /api/shares` を呼び出し、新しいシェアレコードが作成されていた。

### 原因

- `ShareButtons` はマウント時に `createShortUrl(shareParams)` を実行して短縮URLを事前生成する
- `/s/:id` 経由で表示した場合、APIから取得したサムネイルURL付きのパラメータで `params_hash` が計算される
- 元のシェアにはサムネイルURLがなかったため、ハッシュが異なり「新規」と判定されていた

## 修正内容

- `ShareButtons` に `existingShareId` prop を追加
- `existingShareId` がある場合は `createShortUrl`（POST）をスキップし、既存のシェアURLをそのまま使用
- `ShortUrlPage` → `Top3Content` → `ShareButtons` へ ID を伝播

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/components/ShareButtons.tsx` | `existingShareId` prop 追加、URL事前生成ロジック分岐 |
| `src/components/Top3Content.tsx` | `existingShareId` prop 受け渡し |
| `src/pages/ShortUrlPage.tsx` | `Top3Content` に `existingShareId` を渡す |
| `src/components/ShareButtons.test.tsx` | `existingShareId` 時のテスト追加 |
| `src/pages/ShortUrlPage.test.tsx` | ID伝播のテスト追加 |

## テスト

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run test` ✅ (474 tests passed)
- 手動確認: ギャラリーからカードクリック後、DBレコード数が増えないことを確認済み