### PR TITLE
fix(image-proxy): レスポンスサイズ制限を追加してOOMリスクを防止

### DIFF
--- a/src/server/routes/image-proxy.test.ts
+++ b/src/server/routes/image-proxy.test.ts
@@ -151,6 +151,118 @@ describe('image-proxy route', () => {
     })
   })
 
+  it('returns 413 when Content-Length exceeds the size limit', async () => {
+    const overSizeBytes = 11 * 1024 * 1024 // 11MB
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response('too large', {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/jpeg',
+          'Content-Length': String(overSizeBytes),
+        },
+      }),
+    )
+
+    const url = 'https://books.google.com/books/content?id=abc&img=1'
+    const res = await imageProxyApp.request(
+      `/proxy?url=${encodeURIComponent(url)}`,
+    )
+
+    expect(res.status).toBe(413)
+    const json = (await res.json()) as ErrorResponse
+    expect(json.ok).toBe(false)
+    expect(json.error.message).toMatch(/サイズ/)
+  })
+
+  it('allows responses within the size limit', async () => {
+    const imageData = new Uint8Array(1024) // 1KB
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(imageData, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/png',
+          'Content-Length': '1024',
+        },
+      }),
+    )
+
+    const url = 'https://books.google.com/books/content?id=abc&img=1'
+    const res = await imageProxyApp.request(
+      `/proxy?url=${encodeURIComponent(url)}`,
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 413 when streamed body exceeds the size limit without Content-Length', async () => {
+    // Create a ReadableStream that produces chunks exceeding 10MB
+    const chunkSize = 1024 * 1024 // 1MB per chunk
+    let chunksSent = 0
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (chunksSent < 11) {
+          controller.enqueue(new Uint8Array(chunkSize))
+          chunksSent++
+        } else {
+          controller.close()
+        }
+      },
+    })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/jpeg',
+          // No Content-Length header
+        },
+      }),
+    )
+
+    const url = 'https://books.google.com/books/content?id=abc&img=1'
+    const res = await imageProxyApp.request(
+      `/proxy?url=${encodeURIComponent(url)}`,
+    )
+
+    expect(res.status).toBe(413)
+    const json = (await res.json()) as ErrorResponse
+    expect(json.ok).toBe(false)
+    expect(json.error.message).toMatch(/サイズ/)
+  })
+
+  it('streams responses without Content-Length within the size limit', async () => {
+    const chunkSize = 1024
+    let chunksSent = 0
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (chunksSent < 3) {
+          controller.enqueue(new Uint8Array(chunkSize))
+          chunksSent++
+        } else {
+          controller.close()
+        }
+      },
+    })
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: {
+          'Content-Type': 'image/png',
+        },
+      }),
+    )
+
+    const url = 'https://books.google.com/books/content?id=abc&img=1'
+    const res = await imageProxyApp.request(
+      `/proxy?url=${encodeURIComponent(url)}`,
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.arrayBuffer()
+    expect(body.byteLength).toBe(3 * 1024)
+  })
+
   describe('ALLOWED_HOSTS', () => {
     it('includes Google Books domains', () => {
       expect(ALLOWED_HOSTS).toContain('books.google.com')

--- a/src/server/routes/image-proxy.ts
+++ b/src/server/routes/image-proxy.ts
@@ -9,6 +9,7 @@ export const ALLOWED_HOSTS = [
 
 const PROXY_TIMEOUT_MS = 10_000
 const CACHE_MAX_AGE = 86400 // 1 day
+const MAX_RESPONSE_SIZE = 10 * 1024 * 1024 // 10MB
 
 function isAllowedHost(hostname: string): boolean {
   return (ALLOWED_HOSTS as readonly string[]).includes(hostname)
@@ -17,6 +18,48 @@ function isAllowedHost(hostname: string): boolean {
 function isImageContentType(contentType: string | null): boolean {
   if (!contentType) return false
   return contentType.startsWith('image/')
+}
+
+/**
+ * ストリーミングでレスポンスを読み込み、上限を超えたら null を返す。
+ */
+async function readWithSizeLimit(
+  response: Response,
+  maxSize: number,
+): Promise<Uint8Array | null> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    // body がない場合は空を返す
+    return new Uint8Array(0)
+  }
+
+  const chunks: Uint8Array[] = []
+  let totalSize = 0
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      totalSize += value.byteLength
+      if (totalSize > maxSize) {
+        await reader.cancel()
+        return null
+      }
+      chunks.push(value)
+    }
+  } catch {
+    await reader.cancel()
+    throw new Error('ストリーム読み込み中にエラーが発生しました')
+  }
+
+  const result = new Uint8Array(totalSize)
+  let offset = 0
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return result
 }
 
 export const imageProxyApp = new Hono()
@@ -101,7 +144,35 @@ imageProxyApp.get('/proxy', async (c) => {
       )
     }
 
-    const body = await upstream.arrayBuffer()
+    // Content-Length が明示されていて上限超過なら即拒否
+    const contentLength = upstream.headers.get('Content-Length')
+    if (contentLength && Number(contentLength) > MAX_RESPONSE_SIZE) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            kind: 'unknown',
+            message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
+          },
+        },
+        413,
+      )
+    }
+
+    // ストリーミング読み込みでサイズ制限を強制
+    const body = await readWithSizeLimit(upstream, MAX_RESPONSE_SIZE)
+    if (body === null) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            kind: 'unknown',
+            message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
+          },
+        },
+        413,
+      )
+    }
 
     return new Response(body, {
       status: 200,


### PR DESCRIPTION
## 概要

`image-proxy` の上流レスポンスにサイズ制限（10MB）を追加し、巨大画像によるOOM（メモリ枯渇）リスクを防止します。

## 変更内容

### `src/server/routes/image-proxy.ts`
- **`Content-Length` ヘッダによる事前チェック**: 上流レスポンスの `Content-Length` が 10MB を超える場合は即座に 413 を返す
- **`readWithSizeLimit` 関数の追加**: `upstream.arrayBuffer()` による一括読み込みをストリーミング読み込みに置き換え。チャンク単位で累積サイズを監視し、上限超過時にストリームをキャンセルして 413 を返す
- **定数 `MAX_RESPONSE_SIZE`**: 10MB（`10 * 1024 * 1024`）

### `src/server/routes/image-proxy.test.ts`
- Content-Length 超過時の 413 レスポンス
- Content-Length 範囲内の正常レスポンス
- ストリーム読み込み中の超過時の 413 レスポンス（Content-Length なし）
- ストリーム読み込み範囲内の正常レスポンス（Content-Length なし）

Closes #168