### PR TITLE
chore: 不要ファイル・ブランチ・CI残骸のクリーンアップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,5 @@ jobs:
         run: npm run build
         env:
           GOOGLE_BOOKS_API_KEY: dummy
-          SPOTIFY_CLIENT_ID: dummy
-          SPOTIFY_CLIENT_SECRET: dummy
+          LASTFM_API_KEY: dummy
           TMDB_API_KEY: dummy

--- a/src/server/routes/music.ts
+++ b/src/server/routes/music.ts
@@ -4,16 +4,12 @@ import { registerRoutes } from './route-factory.ts'
 
 const app = new Hono()
 
-function getApiKey(): string {
-  return process.env['LASTFM_API_KEY'] ?? ''
-}
-
 registerRoutes(app, {
   name: 'music',
-  getAuth: () => getApiKey(),
+  getAuth: () => process.env['LASTFM_API_KEY'] ?? '',
   authErrorMessage: 'Last.fm API key not configured',
-  searchFn: (apiKey, query, options) => searchMusic(apiKey, query, options),
-  getByIdFn: (apiKey, id) => getMusicById(apiKey, id),
+  searchFn: searchMusic,
+  getByIdFn: getMusicById,
   maxSearchResults: { min: 1, max: 10, default: 10 },
 })
 


### PR DESCRIPTION
## 概要

#175 の対応。プロジェクト内のゴミを整理。

## 変更内容

### 1. CI の Spotify 環境変数を削除
- `.github/workflows/ci.yml` の `build` ジョブから `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` を削除
- 代わりに `LASTFM_API_KEY: dummy` を追加（Last.fm 移行済みのため）

### 2. music.ts のラッパー関数を除去
- `getApiKey()` 関数を除去し、インラインのアロー関数に変更
- `searchFn` / `getByIdFn` のアロー関数ラッパーを除去し、直接参照に変更
- `books.ts` / `movies.ts` と同じスタイルに統一

### 3. ローカルブランチの整理
- リモートで既に削除済みの 21 ブランチをローカルから削除

### 4. `nahshshjsjaj` ファイル
- 調査の結果、Git に追跡されておらず既に存在しないため対応不要

Closes #175