### PR TITLE
refactor: 画像フォールバック(placeholder SVG + onError)の共通化

### DIFF
--- a/src/components/ImageWorkCard.tsx
+++ b/src/components/ImageWorkCard.tsx
@@ -1,5 +1,7 @@
 import type { SearchResultItem } from '../types/common'
 import { proxyImageUrl } from '../utils/proxy-image-url'
+import { SafeImage } from './SafeImage'
+import { CANVAS_PLACEHOLDER } from '../constants/placeholders'
 
 export type ImageWorkCardProps = {
   item: SearchResultItem | null
@@ -24,8 +26,8 @@ const TRUNCATED_TEXT: React.CSSProperties = {
   textAlign: 'center',
 }
 
-export const NO_IMAGE_SRC =
-  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgZmlsbD0iIzM3NDE1MSIvPjx0ZXh0IHg9IjEwMCIgeT0iMTQwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOWNhM2FmIiBmb250LXNpemU9IjE0Ij5ObyBJbWFnZTwvdGV4dD48L3N2Zz4='
+/** @deprecated Use CANVAS_PLACEHOLDER from constants/placeholders instead */
+export const NO_IMAGE_SRC = CANVAS_PLACEHOLDER
 
 export function ImageWorkCard({ item, label }: ImageWorkCardProps) {
   if (!item) {
@@ -94,16 +96,11 @@ export function ImageWorkCard({ item, label }: ImageWorkCardProps) {
       </div>
 
       {/* Thumbnail with enhanced shadow */}
-      <img
+      <SafeImage
         src={proxyImageUrl(item.thumbnailUrl)}
         alt={item.title}
+        fallbackSrc={CANVAS_PLACEHOLDER}
         crossOrigin="anonymous"
-        onError={(e) => {
-          const img = e.target as HTMLImageElement
-          if (img.src !== NO_IMAGE_SRC) {
-            img.src = NO_IMAGE_SRC
-          }
-        }}
         style={{
           width: 210,
           height: 290,

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -1,19 +1,12 @@
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import CardMedia from '@mui/material/CardMedia'
 import Button from '@mui/material/Button'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 import type { SearchResultItem, MediaCategory } from '../types/common'
 import { useSelection } from '../hooks/useSelection'
-
-const NO_IMAGE_PLACEHOLDERS: Record<MediaCategory, string> = {
-  book: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23fef3c7' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%23d97706' font-family='sans-serif' font-size='32'%3E📖%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%23b45309' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
-  music:
-    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23dbeafe' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%232563eb' font-family='sans-serif' font-size='32'%3E🎵%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%231d4ed8' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
-  movie:
-    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23ede9fe' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%237c3aed' font-family='sans-serif' font-size='32'%3E🎬%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%236d28d9' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
-}
+import { CATEGORY_PLACEHOLDERS } from '../constants/placeholders'
+import { SafeImage } from './SafeImage'
 
 const THUMBNAIL_DIMENSIONS: Record<
   MediaCategory,
@@ -32,7 +25,7 @@ type ResultCardProps = {
 export default function ResultCard({ item, onSelect }: ResultCardProps) {
   const { selection } = useSelection()
   const isSelected = selection[item.category]?.id === item.id
-  const placeholder = NO_IMAGE_PLACEHOLDERS[item.category]
+  const placeholder = CATEGORY_PLACEHOLDERS[item.category]
   const dimensions = THUMBNAIL_DIMENSIONS[item.category]
 
   const handleCardClick = () => {
@@ -77,18 +70,15 @@ export default function ResultCard({ item, onSelect }: ResultCardProps) {
       }}
     >
       <div className="relative shrink-0">
-        <CardMedia
-          component="img"
-          sx={{
+        <SafeImage
+          src={item.thumbnailUrl || placeholder}
+          alt={item.title}
+          fallbackSrc={placeholder}
+          style={{
             width: dimensions.width,
             aspectRatio: dimensions.aspectRatio,
             objectFit: 'cover',
-          }}
-          image={item.thumbnailUrl || placeholder}
-          alt={item.title}
-          onError={(e) => {
-            const target = e.target as HTMLImageElement
-            target.src = placeholder
+            display: 'block',
           }}
         />
         {isSelected && (

--- a/src/components/SafeImage.test.tsx
+++ b/src/components/SafeImage.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '../test/test-utils'
+import { SafeImage } from './SafeImage'
+import { DEFAULT_PLACEHOLDER } from '../constants/placeholders'
+
+describe('SafeImage', () => {
+  it('renders img with src and alt', () => {
+    render(<SafeImage src="https://example.com/img.jpg" alt="test" />)
+    const img = screen.getByRole('img', { name: 'test' })
+    expect(img).toHaveAttribute('src', 'https://example.com/img.jpg')
+  })
+
+  it('uses DEFAULT_PLACEHOLDER as fallbackSrc by default', () => {
+    render(<SafeImage src="bad.jpg" alt="test" />)
+    const img = screen.getByRole('img', { name: 'test' })
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', DEFAULT_PLACEHOLDER)
+  })
+
+  it('uses custom fallbackSrc on error', () => {
+    render(<SafeImage src="bad.jpg" alt="test" fallbackSrc="fallback.svg" />)
+    const img = screen.getByRole('img', { name: 'test' })
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', 'fallback.svg')
+  })
+
+  it('does not loop when fallbackSrc also fails', () => {
+    render(<SafeImage src="bad.jpg" alt="test" fallbackSrc="also-bad.svg" />)
+    const img = screen.getByRole('img', { name: 'test' })
+    // first error → set to fallback
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', 'also-bad.svg')
+    // second error → should NOT change src again (no infinite loop)
+    fireEvent.error(img)
+    expect(img).toHaveAttribute('src', 'also-bad.svg')
+  })
+
+  it('passes extra props to img', () => {
+    render(
+      <SafeImage
+        src="test.jpg"
+        alt="test"
+        className="custom-class"
+        data-testid="my-img"
+      />,
+    )
+    const img = screen.getByTestId('my-img')
+    expect(img).toHaveClass('custom-class')
+  })
+})

--- a/src/components/SafeImage.tsx
+++ b/src/components/SafeImage.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useRef } from 'react'
+import { DEFAULT_PLACEHOLDER } from '../constants/placeholders'
+
+type SafeImageProps = React.ComponentPropsWithoutRef<'img'> & {
+  fallbackSrc?: string
+}
+
+/**
+ * `<img>` wrapper that swaps to a fallback on error.
+ * Prevents infinite loops when the fallback itself fails.
+ */
+export function SafeImage({
+  fallbackSrc = DEFAULT_PLACEHOLDER,
+  onError,
+  ...props
+}: SafeImageProps) {
+  const hasFailed = useRef(false)
+
+  const handleError = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      if (!hasFailed.current) {
+        hasFailed.current = true
+        e.currentTarget.src = fallbackSrc
+      }
+      onError?.(e)
+    },
+    [fallbackSrc, onError],
+  )
+
+  return <img {...props} onError={handleError} />
+}

--- a/src/components/SelectionArea.tsx
+++ b/src/components/SelectionArea.tsx
@@ -6,6 +6,8 @@ import CloseIcon from '@mui/icons-material/Close'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { useNavigate } from 'react-router-dom'
 import { useSelection } from '../hooks/useSelection'
+import { SafeImage } from './SafeImage'
+import { DEFAULT_PLACEHOLDER } from '../constants/placeholders'
 import { buildTop3Url } from '../utils/url-params'
 import type { MediaCategory, SearchResultItem } from '../types/common'
 import { CATEGORY_LABELS_EN } from '../constants/category'
@@ -85,14 +87,11 @@ function SlotCard({
       >
         <CloseIcon sx={{ fontSize: 16 }} />
       </IconButton>
-      <img
+      <SafeImage
         src={item.thumbnailUrl}
         alt={item.title}
+        fallbackSrc={DEFAULT_PLACEHOLDER}
         className="h-16 w-12 rounded object-cover"
-        onError={(e) => {
-          ;(e.target as HTMLImageElement).src = ''
-          ;(e.target as HTMLImageElement).alt = 'No Image'
-        }}
       />
       <div className="min-w-0 flex-1 pr-4">
         <span

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -1,9 +1,8 @@
 import Skeleton from '@mui/material/Skeleton'
 import Button from '@mui/material/Button'
 import type { SearchResultItem } from '../types/common'
-
-const DEFAULT_THUMBNAIL =
-  'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="128" height="176" fill="%23e5e7eb"><rect width="128" height="176"/><text x="64" y="92" text-anchor="middle" fill="%239ca3af" font-size="12">No Image</text></svg>'
+import { SafeImage } from './SafeImage'
+import { DEFAULT_PLACEHOLDER } from '../constants/placeholders'
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string }> = {
   BOOK: { bg: '#6366f1', text: '#ffffff' },
@@ -131,16 +130,11 @@ function WorkCard({ work, loading, error, label, onRetry }: WorkCardProps) {
           </div>
         </div>
 
-        <img
+        <SafeImage
           src={work.thumbnailUrl}
           alt={work.title}
+          fallbackSrc={DEFAULT_PLACEHOLDER}
           className="mb-3 h-44 w-32 rounded-lg object-cover shadow-md transition-transform duration-300 group-hover:scale-105"
-          onError={(e) => {
-            const img = e.target as HTMLImageElement
-            if (img.src !== DEFAULT_THUMBNAIL) {
-              img.src = DEFAULT_THUMBNAIL
-            }
-          }}
         />
         <p className="text-center text-[0.85rem] font-semibold leading-tight">
           {work.title}

--- a/src/constants/image-layout.ts
+++ b/src/constants/image-layout.ts
@@ -19,8 +19,8 @@ export const CATEGORY_BORDER_COLORS: Record<MediaCategory, string> = {
   movie: 'rgba(251,113,133,0.4)',
 }
 
-export const NO_IMAGE_SRC =
-  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgZmlsbD0iIzM3NDE1MSIvPjx0ZXh0IHg9IjEwMCIgeT0iMTQwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOWNhM2FmIiBmb250LXNpemU9IjE0Ij5ObyBJbWFnZTwvdGV4dD48L3N2Zz4='
+/** @deprecated Use CANVAS_PLACEHOLDER from constants/placeholders instead */
+export { CANVAS_PLACEHOLDER as NO_IMAGE_SRC } from './placeholders'
 
 export const DEFAULT_LAYOUT: LayoutConfig = {
   top: 'music',

--- a/src/constants/placeholders.test.ts
+++ b/src/constants/placeholders.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_PLACEHOLDER,
+  CATEGORY_PLACEHOLDERS,
+  CANVAS_PLACEHOLDER,
+} from './placeholders'
+import type { MediaCategory } from '../types/common'
+
+const CATEGORIES: MediaCategory[] = ['book', 'music', 'movie']
+
+describe('DEFAULT_PLACEHOLDER', () => {
+  it('is a data URI SVG', () => {
+    expect(DEFAULT_PLACEHOLDER).toMatch(/^data:image\/svg/)
+  })
+})
+
+describe('CATEGORY_PLACEHOLDERS', () => {
+  it.each(CATEGORIES)('has a placeholder for %s', (cat) => {
+    expect(CATEGORY_PLACEHOLDERS[cat]).toMatch(/^data:image\/svg/)
+  })
+
+  it('covers all MediaCategory values', () => {
+    expect(Object.keys(CATEGORY_PLACEHOLDERS).sort()).toEqual(
+      [...CATEGORIES].sort(),
+    )
+  })
+})
+
+describe('CANVAS_PLACEHOLDER', () => {
+  it('is a base64-encoded data URI', () => {
+    expect(CANVAS_PLACEHOLDER).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
+})

--- a/src/constants/placeholders.ts
+++ b/src/constants/placeholders.ts
@@ -1,0 +1,18 @@
+import type { MediaCategory } from '../types/common'
+
+/** Generic grey placeholder (used in WorkCard etc.) */
+export const DEFAULT_PLACEHOLDER =
+  'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="128" height="176" fill="%23e5e7eb"><rect width="128" height="176"/><text x="64" y="92" text-anchor="middle" fill="%239ca3af" font-size="12">No Image</text></svg>'
+
+/** Category-specific placeholders with emoji icons */
+export const CATEGORY_PLACEHOLDERS: Record<MediaCategory, string> = {
+  book: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23fef3c7' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%23d97706' font-family='sans-serif' font-size='32'%3E📖%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%23b45309' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
+  music:
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23dbeafe' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%232563eb' font-family='sans-serif' font-size='32'%3E🎵%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%231d4ed8' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
+  movie:
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='160' viewBox='0 0 120 160'%3E%3Crect fill='%23ede9fe' width='120' height='160'/%3E%3Ctext x='50%25' y='45%25' dominant-baseline='middle' text-anchor='middle' fill='%237c3aed' font-family='sans-serif' font-size='32'%3E🎬%3C/text%3E%3Ctext x='50%25' y='65%25' dominant-baseline='middle' text-anchor='middle' fill='%236d28d9' font-family='sans-serif' font-size='11'%3ENo Image%3C/text%3E%3C/svg%3E",
+}
+
+/** Dark-themed placeholder for canvas/image generation (base64) */
+export const CANVAS_PLACEHOLDER =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjI4MCIgZmlsbD0iIzM3NDE1MSIvPjx0ZXh0IHg9IjEwMCIgeT0iMTQwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOWNhM2FmIiBmb250LXNpemU9IjE0Ij5ObyBJbWFnZTwvdGV4dD48L3N2Zz4='


### PR DESCRIPTION
## 概要

Issue #198 の対応。画像の placeholder SVG と `onError` フォールバックハンドラの重複を共通化。

## 変更内容

### 新規ファイル
- **`src/constants/placeholders.ts`** — placeholder SVG 定数を集約
  - `DEFAULT_PLACEHOLDER`: 汎用グレー SVG（WorkCard, SelectionArea 用）
  - `CATEGORY_PLACEHOLDERS`: カテゴリ別 SVG × 3（ResultCard 用）
  - `CANVAS_PLACEHOLDER`: canvas 生成用 base64 SVG（ImageWorkCard 用）
- **`src/components/SafeImage.tsx`** — `<SafeImage src fallbackSrc />` コンポーネント
  - `useRef` で無限ループ防止
  - 全 `img` の `onError` 処理を一元化

### リファクタリング対象
- `WorkCard.tsx` — `DEFAULT_THUMBNAIL` 削除 → `SafeImage` + `DEFAULT_PLACEHOLDER`
- `ResultCard.tsx` — `NO_IMAGE_PLACEHOLDERS` 削除 → `CATEGORY_PLACEHOLDERS` + `SafeImage`、`CardMedia` → `SafeImage` に置換
- `ImageWorkCard.tsx` — `NO_IMAGE_SRC` を re-export に変更 → `SafeImage` + `CANVAS_PLACEHOLDER`
- `SelectionArea.tsx` — インラインフォールバック削除 → `SafeImage` + `DEFAULT_PLACEHOLDER`
- `image-layout.ts` — `NO_IMAGE_SRC` を `CANVAS_PLACEHOLDER` の re-export に変更（deprecated）

### テスト
- `placeholders.test.ts` — 定数の存在・形式テスト
- `SafeImage.test.tsx` — レンダリング、フォールバック動作、無限ループ防止テスト

## 削減
~40行の重複コードを削減

Closes #198