### PR TITLE
refactor: 外部APIサービスのキャッシュ・共通処理の共通化

### DIFF
--- a/src/services/google-books.ts
+++ b/src/services/google-books.ts
@@ -4,27 +4,20 @@ import type {
   SearchResultItem,
 } from '../types/common.ts'
 import { fetchJson } from '../utils/fetch-client.ts'
-import { TtlCache } from '../utils/cache.ts'
 import {
   assertObject,
   assertField,
   assertOptionalArray,
 } from './validation-helpers.ts'
+import { createServiceCaches, EMPTY_SEARCH_RESULT } from './service-cache.ts'
 
 const BASE_URL = 'https://www.googleapis.com/books/v1/volumes'
 const DEFAULT_MAX_RESULTS = 20
 
-const SEARCH_TTL_MS = 5 * 60 * 1000 // 5 minutes
-const GET_BY_ID_TTL_MS = 60 * 60 * 1000 // 1 hour
-
-const searchCache = new TtlCache<Result<PaginatedResponse<SearchResultItem>>>({
-  ttlMs: SEARCH_TTL_MS,
-  maxEntries: 200,
-})
-const getByIdCache = new TtlCache<Result<SearchResultItem>>({
-  ttlMs: GET_BY_ID_TTL_MS,
-  maxEntries: 500,
-})
+const { searchCache, getByIdCache, clearCaches } = createServiceCaches<
+  Result<PaginatedResponse<SearchResultItem>>,
+  Result<SearchResultItem>
+>()
 
 type GoogleBooksImageLinks = {
   smallThumbnail?: string
@@ -123,12 +116,7 @@ export async function searchBooks(
   const { startIndex = 0, maxResults = DEFAULT_MAX_RESULTS, signal } = options
 
   const trimmed = query.trim()
-  if (trimmed === '') {
-    return {
-      ok: true,
-      data: { items: [], totalItems: 0, startIndex: 0 },
-    }
-  }
+  if (trimmed === '') return EMPTY_SEARCH_RESULT
 
   const cacheKey = `${trimmed}:${startIndex}:${maxResults}`
 
@@ -217,10 +205,7 @@ export async function getBookById(
 }
 
 /** @internal Clear caches (for testing only) */
-export function _clearCaches(): void {
-  searchCache.clear()
-  getByIdCache.clear()
-}
+export const _clearCaches = clearCaches
 
 function mapVolumeToSearchResult(volume: GoogleBooksVolume): SearchResultItem {
   const info = volume.volumeInfo

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -4,23 +4,16 @@ import type {
   SearchResultItem,
 } from '../types/common.ts'
 import { fetchJson } from '../utils/fetch-client.ts'
-import { TtlCache } from '../utils/cache.ts'
 import { assertObject, assertField, assertArray } from './validation-helpers.ts'
+import { createServiceCaches, EMPTY_SEARCH_RESULT } from './service-cache.ts'
 
 const BASE_URL = 'https://ws.audioscrobbler.com/2.0'
 const DEFAULT_MAX_RESULTS = 20
 
-const SEARCH_TTL_MS = 5 * 60 * 1000 // 5 minutes
-const GET_BY_ID_TTL_MS = 60 * 60 * 1000 // 1 hour
-
-const searchCache = new TtlCache<Result<PaginatedResponse<SearchResultItem>>>({
-  ttlMs: SEARCH_TTL_MS,
-  maxEntries: 200,
-})
-const getByIdCache = new TtlCache<Result<SearchResultItem>>({
-  ttlMs: GET_BY_ID_TTL_MS,
-  maxEntries: 500,
-})
+const { searchCache, getByIdCache, clearCaches } = createServiceCaches<
+  Result<PaginatedResponse<SearchResultItem>>,
+  Result<SearchResultItem>
+>()
 
 // ── Last.fm API response types ──────────────────────────────────────
 
@@ -112,12 +105,7 @@ export async function searchMusic(
   const { startIndex = 0, maxResults = DEFAULT_MAX_RESULTS, signal } = options
 
   const trimmed = query.trim()
-  if (trimmed === '') {
-    return {
-      ok: true,
-      data: { items: [], totalItems: 0, startIndex: 0 },
-    }
-  }
+  if (trimmed === '') return EMPTY_SEARCH_RESULT
 
   // Last.fm uses 1-based page numbers
   const page = Math.floor(startIndex / maxResults) + 1
@@ -222,10 +210,7 @@ export async function getMusicById(
 }
 
 /** @internal Clear caches (for testing only) */
-export function _clearCaches(): void {
-  searchCache.clear()
-  getByIdCache.clear()
-}
+export const _clearCaches = clearCaches
 
 // ── Mapping ─────────────────────────────────────────────────────────
 

--- a/src/services/service-cache.test.ts
+++ b/src/services/service-cache.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createServiceCaches,
+  EMPTY_SEARCH_RESULT,
+  SEARCH_TTL_MS,
+  GET_BY_ID_TTL_MS,
+  SEARCH_MAX_ENTRIES,
+  GET_BY_ID_MAX_ENTRIES,
+} from './service-cache'
+import type {
+  PaginatedResponse,
+  Result,
+  SearchResultItem,
+} from '../types/common'
+
+describe('EMPTY_SEARCH_RESULT', () => {
+  it('returns ok with empty items, totalItems 0, startIndex 0', () => {
+    expect(EMPTY_SEARCH_RESULT).toEqual({
+      ok: true,
+      data: { items: [], totalItems: 0, startIndex: 0 },
+    })
+  })
+
+  it('has the correct shape', () => {
+    expect(EMPTY_SEARCH_RESULT.ok).toBe(true)
+    if (EMPTY_SEARCH_RESULT.ok) {
+      expect(EMPTY_SEARCH_RESULT.data.items).toEqual([])
+    }
+  })
+})
+
+describe('TTL and size constants', () => {
+  it('has correct TTL values', () => {
+    expect(SEARCH_TTL_MS).toBe(5 * 60 * 1000)
+    expect(GET_BY_ID_TTL_MS).toBe(60 * 60 * 1000)
+  })
+
+  it('has correct max entries', () => {
+    expect(SEARCH_MAX_ENTRIES).toBe(200)
+    expect(GET_BY_ID_MAX_ENTRIES).toBe(500)
+  })
+})
+
+describe('createServiceCaches', () => {
+  it('returns searchCache, getByIdCache, and clearCaches', () => {
+    const caches = createServiceCaches<
+      Result<PaginatedResponse<SearchResultItem>>,
+      Result<SearchResultItem>
+    >()
+    expect(caches).toHaveProperty('searchCache')
+    expect(caches).toHaveProperty('getByIdCache')
+    expect(caches).toHaveProperty('clearCaches')
+  })
+
+  it('searchCache stores and retrieves values', () => {
+    const { searchCache } = createServiceCaches<string, string>()
+    searchCache.set('key1', 'value1')
+    expect(searchCache.get('key1')).toBe('value1')
+  })
+
+  it('getByIdCache stores and retrieves values', () => {
+    const { getByIdCache } = createServiceCaches<string, string>()
+    getByIdCache.set('id1', 'detail1')
+    expect(getByIdCache.get('id1')).toBe('detail1')
+  })
+
+  it('clearCaches clears both caches', () => {
+    const { searchCache, getByIdCache, clearCaches } = createServiceCaches<
+      string,
+      string
+    >()
+    searchCache.set('k', 'v')
+    getByIdCache.set('k', 'v')
+    expect(searchCache.size).toBe(1)
+    expect(getByIdCache.size).toBe(1)
+
+    clearCaches()
+    expect(searchCache.size).toBe(0)
+    expect(getByIdCache.size).toBe(0)
+  })
+
+  it('creates independent cache instances per call', () => {
+    const a = createServiceCaches<string, string>()
+    const b = createServiceCaches<string, string>()
+    a.searchCache.set('k', 'a')
+    b.searchCache.set('k', 'b')
+    expect(a.searchCache.get('k')).toBe('a')
+    expect(b.searchCache.get('k')).toBe('b')
+  })
+})

--- a/src/services/service-cache.ts
+++ b/src/services/service-cache.ts
@@ -1,0 +1,50 @@
+import type {
+  PaginatedResponse,
+  Result,
+  SearchResultItem,
+} from '../types/common.ts'
+import { TtlCache } from '../utils/cache.ts'
+
+// ── Shared constants ────────────────────────────────────────────────
+
+export const SEARCH_TTL_MS = 5 * 60 * 1000 // 5 minutes
+export const GET_BY_ID_TTL_MS = 60 * 60 * 1000 // 1 hour
+export const SEARCH_MAX_ENTRIES = 200
+export const GET_BY_ID_MAX_ENTRIES = 500
+
+export const EMPTY_SEARCH_RESULT: Result<PaginatedResponse<SearchResultItem>> =
+  {
+    ok: true,
+    data: { items: [], totalItems: 0, startIndex: 0 },
+  }
+
+// ── Cache factory ───────────────────────────────────────────────────
+
+export type ServiceCaches<TSearch, TGetById> = {
+  searchCache: TtlCache<TSearch>
+  getByIdCache: TtlCache<TGetById>
+  clearCaches: () => void
+}
+
+export function createServiceCaches<TSearch, TGetById>(): ServiceCaches<
+  TSearch,
+  TGetById
+> {
+  const searchCache = new TtlCache<TSearch>({
+    ttlMs: SEARCH_TTL_MS,
+    maxEntries: SEARCH_MAX_ENTRIES,
+  })
+  const getByIdCache = new TtlCache<TGetById>({
+    ttlMs: GET_BY_ID_TTL_MS,
+    maxEntries: GET_BY_ID_MAX_ENTRIES,
+  })
+
+  return {
+    searchCache,
+    getByIdCache,
+    clearCaches: () => {
+      searchCache.clear()
+      getByIdCache.clear()
+    },
+  }
+}

--- a/src/services/tmdb.ts
+++ b/src/services/tmdb.ts
@@ -4,25 +4,18 @@ import type {
   SearchResultItem,
 } from '../types/common.ts'
 import { fetchJson } from '../utils/fetch-client.ts'
-import { TtlCache } from '../utils/cache.ts'
 import { assertObject, assertField, assertArray } from './validation-helpers.ts'
+import { createServiceCaches, EMPTY_SEARCH_RESULT } from './service-cache.ts'
 
 const BASE_URL = 'https://api.themoviedb.org/3'
 const IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/w300'
 const DEFAULT_MAX_RESULTS = 20
 const TMDB_PAGE_SIZE = 20
 
-const SEARCH_TTL_MS = 5 * 60 * 1000 // 5 minutes
-const GET_BY_ID_TTL_MS = 60 * 60 * 1000 // 1 hour
-
-const searchCache = new TtlCache<Result<PaginatedResponse<SearchResultItem>>>({
-  ttlMs: SEARCH_TTL_MS,
-  maxEntries: 200,
-})
-const getByIdCache = new TtlCache<Result<SearchResultItem>>({
-  ttlMs: GET_BY_ID_TTL_MS,
-  maxEntries: 500,
-})
+const { searchCache, getByIdCache, clearCaches } = createServiceCaches<
+  Result<PaginatedResponse<SearchResultItem>>,
+  Result<SearchResultItem>
+>()
 
 // ── TMDb API response types ────────────────────────────────────────
 
@@ -114,12 +107,7 @@ export async function searchMovies(
   const { startIndex = 0, maxResults = DEFAULT_MAX_RESULTS, signal } = options
 
   const trimmed = query.trim()
-  if (trimmed === '') {
-    return {
-      ok: true,
-      data: { items: [], totalItems: 0, startIndex: 0 },
-    }
-  }
+  if (trimmed === '') return EMPTY_SEARCH_RESULT
 
   const page = startIndexToPage(startIndex)
   const cacheKey = `${trimmed}:${page}:${maxResults}`
@@ -205,10 +193,7 @@ function extractYear(releaseDate?: string): string {
 }
 
 /** @internal Clear caches (for testing only) */
-export function _clearCaches(): void {
-  searchCache.clear()
-  getByIdCache.clear()
-}
+export const _clearCaches = clearCaches
 
 function mapMovieToSearchResult(movie: TMDbMovie): SearchResultItem {
   return {


### PR DESCRIPTION
## 概要

Closes #200

外部APIサービス (lastfm, google-books, tmdb) で重複していたキャッシュ宣言・空クエリ早期リターン・`_clearCaches()` を共通モジュールに抽出。

## 変更内容

### 新規ファイル
- **`src/services/service-cache.ts`** — `createServiceCaches()` ファクトリ + `EMPTY_SEARCH_RESULT` 定数
- **`src/services/service-cache.test.ts`** — ファクトリのユニットテスト (9テスト)

### 修正ファイル
- **`src/services/lastfm.ts`** — キャッシュ宣言・空クエリリターン・`_clearCaches` を共通化
- **`src/services/google-books.ts`** — 同上
- **`src/services/tmdb.ts`** — 同上

## 削減量
```
 src/services/google-books.ts       | 29 +++---------
 src/services/lastfm.ts             | 29 +++---------
 src/services/tmdb.ts               | 29 +++---------
 5 files changed, 161 insertions(+), 66 deletions(-)
```

各サービスファイルから約15-20行の重複コードを削減。

## チェック
- [x] `npm run lint` — pass (warnings only, pre-existing)
- [x] `npm run format:check` — pass
- [x] `npm run typecheck` — pass
- [x] `npm run test` — 527 tests pass