### PR TITLE
refactor: categoryToPath() と API_ENDPOINTS の知識重複を解消

### DIFF
--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -158,4 +158,50 @@ describe('useSearch', () => {
     expect(result.current.hasMore).toBe(false)
     expect(result.current.results).toEqual([])
   })
+
+  it('uses API_ENDPOINTS for music category', async () => {
+    let requestedUrl = ''
+    server.use(
+      http.get('/api/music/search', ({ request }) => {
+        requestedUrl = new URL(request.url).pathname
+        return HttpResponse.json({
+          ok: true,
+          data: {
+            items: [{ id: 'm1', title: 'Test Music', category: 'music' }],
+            totalItems: 1,
+            startIndex: 0,
+          },
+        })
+      }),
+    )
+    const { result } = renderHook(() => useSearch('music', 'test'))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(requestedUrl).toBe('/api/music/search')
+    expect(result.current.results[0].category).toBe('music')
+  })
+
+  it('uses API_ENDPOINTS for movie category', async () => {
+    let requestedUrl = ''
+    server.use(
+      http.get('/api/movies/search', ({ request }) => {
+        requestedUrl = new URL(request.url).pathname
+        return HttpResponse.json({
+          ok: true,
+          data: {
+            items: [{ id: 'mv1', title: 'Test Movie', category: 'movie' }],
+            totalItems: 1,
+            startIndex: 0,
+          },
+        })
+      }),
+    )
+    const { result } = renderHook(() => useSearch('movie', 'test'))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(requestedUrl).toBe('/api/movies/search')
+    expect(result.current.results[0].category).toBe('movie')
+  })
 })

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,19 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { MediaCategory, SearchResultItem } from '../types/common'
 import { MESSAGES } from '../constants/messages'
+import { API_ENDPOINTS } from '../constants/category'
 
 const MAX_RESULTS = 20
-
-function categoryToPath(category: MediaCategory): string {
-  switch (category) {
-    case 'book':
-      return 'books'
-    case 'music':
-      return 'music'
-    case 'movie':
-      return 'movies'
-  }
-}
 
 type UseSearchReturn = {
   results: SearchResultItem[]
@@ -57,16 +47,18 @@ export function useSearch(
       setError(null)
 
       try {
-        const path = categoryToPath(category)
         const params = new URLSearchParams({
           q: query.trim(),
           startIndex: String(index),
           maxResults: String(MAX_RESULTS),
         })
 
-        const response = await fetch(`/api/${path}/search?${params}`, {
-          signal: controller.signal,
-        })
+        const response = await fetch(
+          `${API_ENDPOINTS[category]}/search?${params}`,
+          {
+            signal: controller.signal,
+          },
+        )
 
         if (!response.ok) {
           if (response.status === 429) {


### PR DESCRIPTION
## 概要

`useSearch.ts` の `categoryToPath()` switch文を削除し、`constants/category.ts` の `API_ENDPOINTS` を直接使用するように変更。

## 変更内容

- `categoryToPath()` 関数（~10行）を削除
- `API_ENDPOINTS[category]` を import して `fetch` URL を組み立て
- `music` / `movie` カテゴリのエンドポイントテストを追加

## チェック

- [x] lint
- [x] format:check
- [x] typecheck
- [x] test (529 passed)

Closes #201