### PR TITLE
テーマサジェスションの年を動的に現在年へ変更

### DIFF
--- a/src/components/ThemeInput.test.tsx
+++ b/src/components/ThemeInput.test.tsx
@@ -36,7 +36,9 @@ it('renders suggestion chips', () => {
   render(<ThemeInput value="" onChange={vi.fn()} />)
   expect(screen.getByText('夏に読みたい')).toBeInTheDocument()
   expect(screen.getByText('青春')).toBeInTheDocument()
-  expect(screen.getByText('2024年ベスト')).toBeInTheDocument()
+  expect(
+    screen.getByText(`${new Date().getFullYear()}年ベスト`),
+  ).toBeInTheDocument()
 })
 
 it('calls onChange when a suggestion chip is clicked', async () => {

--- a/src/components/ThemeInput.tsx
+++ b/src/components/ThemeInput.tsx
@@ -2,7 +2,11 @@ import TextField from '@mui/material/TextField'
 import Chip from '@mui/material/Chip'
 import { MAX_THEME_LENGTH } from '../hooks/useTheme'
 
-const THEME_SUGGESTIONS = ['夏に読みたい', '青春', '2024年ベスト'] as const
+const THEME_SUGGESTIONS = [
+  '夏に読みたい',
+  '青春',
+  `${new Date().getFullYear()}年ベスト`,
+]
 
 type ThemeInputProps = {
   value: string


### PR DESCRIPTION
## 変更内容

テーマサジェスションの「2024年ベスト」がハードコードされていたため、画面表示時の年が動的に反映されるよう変更しました。

### 変更ファイル

- `src/components/ThemeInput.tsx`: `'2024年ベスト'` → `\`${new Date().getFullYear()}年ベスト\``
- `src/components/ThemeInput.test.tsx`: テストも動的な年で検証するよう修正