### PR TITLE
refactor: useSearchPage の冗長なハンドラ関数を簡素化

### DIFF
--- a/src/hooks/useSearchPage.ts
+++ b/src/hooks/useSearchPage.ts
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import type { MediaCategory, SearchResultItem } from '../types/common'
+import type { MediaCategory } from '../types/common'
 import { useDebounce } from './useDebounce'
 import { useSearch } from './useSearch'
 import { useSearchHistory } from './useSearchHistory'
@@ -77,27 +77,6 @@ export function useSearchPage() {
     [activeTab],
   )
 
-  const handleHistorySearch = useCallback(
-    (keyword: string) => {
-      setQueries((prev) => ({ ...prev, [activeTab]: keyword }))
-    },
-    [activeTab],
-  )
-
-  const handleSelect = useCallback(
-    (item: SearchResultItem) => {
-      selectItem(item)
-    },
-    [selectItem],
-  )
-
-  const handleThemeHistorySelect = useCallback(
-    (selectedTheme: string) => {
-      setTheme(selectedTheme)
-    },
-    [setTheme],
-  )
-
   const [selectionComplete, setSelectionComplete] = useState(false)
 
   const handleBeforeCreate = useCallback(() => {
@@ -107,17 +86,6 @@ export function useSearchPage() {
   const handleCompleteChange = useCallback((complete: boolean) => {
     setSelectionComplete(complete)
   }, [])
-
-  const mainStyle = useMemo(
-    () => ({
-      background:
-        'linear-gradient(180deg, #3730a3 0%, var(--color-primary-dark) 12%, var(--color-bg) 32%, #eef2ff 100%)',
-      paddingBottom: selectionComplete
-        ? 'calc(72px + env(safe-area-inset-bottom))'
-        : undefined,
-    }),
-    [selectionComplete],
-  )
 
   return {
     activeTab,
@@ -131,12 +99,10 @@ export function useSearchPage() {
     error,
     loadMore,
     hasMore,
+    selectionComplete,
     handleQueryChange,
-    handleHistorySearch,
-    handleSelect,
-    handleThemeHistorySelect,
+    selectItem,
     handleBeforeCreate,
     handleCompleteChange,
-    mainStyle,
   }
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import StepGuide from '../components/StepGuide'
 import TabSwitcher from '../components/TabSwitcher'
@@ -23,14 +24,23 @@ function SearchPage() {
     error,
     loadMore,
     hasMore,
+    selectionComplete,
     handleQueryChange,
-    handleHistorySearch,
-    handleSelect,
-    handleThemeHistorySelect,
+    selectItem,
     handleBeforeCreate,
     handleCompleteChange,
-    mainStyle,
   } = useSearchPage()
+
+  const mainStyle = useMemo(
+    () => ({
+      background:
+        'linear-gradient(180deg, #3730a3 0%, var(--color-primary-dark) 12%, var(--color-bg) 32%, #eef2ff 100%)',
+      paddingBottom: selectionComplete
+        ? 'calc(72px + env(safe-area-inset-bottom))'
+        : undefined,
+    }),
+    [selectionComplete],
+  )
 
   return (
     <div className="min-h-screen" style={mainStyle}>
@@ -101,7 +111,7 @@ function SearchPage() {
             }}
           >
             <ThemeInput value={theme} onChange={setTheme} />
-            <ThemeHistory onSelect={handleThemeHistorySelect} />
+            <ThemeHistory onSelect={setTheme} />
           </div>
         </div>
 
@@ -143,10 +153,7 @@ function SearchPage() {
           </div>
 
           {!currentQuery.trim() && (
-            <SearchHistory
-              category={activeTab}
-              onSearch={handleHistorySearch}
-            />
+            <SearchHistory category={activeTab} onSearch={handleQueryChange} />
           )}
 
           <SearchResults
@@ -154,7 +161,7 @@ function SearchPage() {
             isLoading={isLoading}
             hasMore={hasMore}
             onLoadMore={loadMore}
-            onSelect={handleSelect}
+            onSelect={selectItem}
             query={debouncedQuery}
             error={error}
           />


### PR DESCRIPTION
## 概要

`useSearchPage.ts` の冗長なハンドラ関数を簡素化し、約27行を削減しました。

## 変更内容

| Before | After | 理由 |
|--------|-------|------|
| `handleQueryChange` + `handleHistorySearch` | `handleQueryChange` のみ | 完全に同一ロジック |
| `handleSelect` (trivialラッパー) | `selectItem` を直接 return | ラッパー不要 |
| `handleThemeHistorySelect` (trivialラッパー) | `setTheme` を直接利用（既に return 済み） | ラッパー不要 |
| `mainStyle` (hook内) | `SearchPage.tsx` コンポーネント側に移動 | プレゼンテーションロジックの分離 |

## チェックリスト

- [x] `npm run lint` ✅
- [x] `npm run format:check` ✅
- [x] `npm run typecheck` ✅
- [x] `npm run test` ✅ (529 tests passed)

Closes #202