### PR TITLE
fix: ギャラリーでサムネイルが「タップして見る」になる問題を修正

### DIFF
--- a/src/components/ShareButtons.test.tsx
+++ b/src/components/ShareButtons.test.tsx
@@ -32,6 +32,7 @@ describe('ShareButtons', () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     })
+    vi.mocked(createShortUrl).mockReset()
   })
 
   afterEach(() => {
@@ -434,6 +435,9 @@ describe('ShareButtons', () => {
         bookId: 'b1',
         musicId: 'm1',
         movieId: 'mv1',
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: 'https://example.com/music.jpg',
+        movieThumb: 'https://example.com/movie.jpg',
       }
 
       render(<ShareButtons theme="テスト" shareParams={shareParams} />)
@@ -459,6 +463,83 @@ describe('ShareButtons', () => {
       expect(createShortUrl).toHaveBeenCalledTimes(1)
     })
 
+    it('does not call createShortUrl when thumbnails are all empty', async () => {
+      vi.mocked(createShortUrl).mockResolvedValue('/s/abc123')
+
+      const shareParams = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: 'm1',
+        movieId: 'mv1',
+        bookThumb: '',
+        musicThumb: '',
+        movieThumb: '',
+      }
+
+      render(<ShareButtons theme="テスト" shareParams={shareParams} />)
+
+      // Wait a tick to confirm no call is made
+      await new Promise((r) => setTimeout(r, 50))
+      expect(createShortUrl).not.toHaveBeenCalled()
+    })
+
+    it('calls createShortUrl once thumbnails are provided', async () => {
+      vi.mocked(createShortUrl).mockResolvedValue('/s/abc123')
+
+      const paramsWithoutThumbs = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: 'm1',
+        movieId: 'mv1',
+        bookThumb: '',
+        musicThumb: '',
+        movieThumb: '',
+      }
+
+      const paramsWithThumbs = {
+        ...paramsWithoutThumbs,
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: 'https://example.com/music.jpg',
+        movieThumb: 'https://example.com/movie.jpg',
+      }
+
+      const { rerender } = render(
+        <ShareButtons theme="テスト" shareParams={paramsWithoutThumbs} />,
+      )
+
+      // Should not call yet
+      await new Promise((r) => setTimeout(r, 50))
+      expect(createShortUrl).not.toHaveBeenCalled()
+
+      // Re-render with thumbnails provided
+      rerender(<ShareButtons theme="テスト" shareParams={paramsWithThumbs} />)
+
+      await waitFor(() => {
+        expect(createShortUrl).toHaveBeenCalledWith(paramsWithThumbs)
+      })
+    })
+
+    it('calls createShortUrl when some categories have no ID (partial selection)', async () => {
+      vi.mocked(createShortUrl).mockResolvedValue('/s/abc123')
+
+      // Only book is selected, music and movie are empty
+      const shareParams = {
+        theme: 'テスト',
+        bookId: 'b1',
+        musicId: '',
+        movieId: '',
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: '',
+        movieThumb: '',
+      }
+
+      render(<ShareButtons theme="テスト" shareParams={shareParams} />)
+
+      await waitFor(() => {
+        expect(createShortUrl).toHaveBeenCalledWith(shareParams)
+      })
+    })
+
     it('falls back to current URL when pre-resolution fails', async () => {
       vi.mocked(createShortUrl).mockRejectedValue(new Error('network error'))
       const shareMock = vi.fn().mockResolvedValue(undefined)
@@ -469,6 +550,9 @@ describe('ShareButtons', () => {
         bookId: 'b1',
         musicId: 'm1',
         movieId: 'mv1',
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: 'https://example.com/music.jpg',
+        movieThumb: 'https://example.com/movie.jpg',
       }
 
       render(<ShareButtons theme="テスト" shareParams={shareParams} />)

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -48,7 +48,9 @@ export default function ShareButtons({
   const handleCloseError = useCallback(() => setCopyFailed(false), [])
   const handleCloseShareError = useCallback(() => setShareFailed(false), [])
 
-  // Pre-resolve short URL on mount so it's ready when user taps share
+  // Pre-resolve short URL on mount so it's ready when user taps share.
+  // Wait until thumbnails are loaded for categories that have an ID,
+  // otherwise the share record would be saved with empty thumbnails.
   useEffect(() => {
     // If we already have a share ID (e.g. viewing from /s/:id), use it directly
     if (existingShareId) {
@@ -56,6 +58,14 @@ export default function ShareButtons({
       return
     }
     if (!shareParams) return
+
+    // Check that thumbnails are ready for all selected categories
+    const thumbsReady =
+      (!shareParams.bookId || !!shareParams.bookThumb) &&
+      (!shareParams.musicId || !!shareParams.musicThumb) &&
+      (!shareParams.movieId || !!shareParams.movieThumb)
+    if (!thumbsReady) return
+
     let cancelled = false
     createShortUrl(shareParams)
       .then((shortPath) => {

--- a/src/server/share-store.test.ts
+++ b/src/server/share-store.test.ts
@@ -147,6 +147,56 @@ describe('share-store', () => {
       store.close()
     })
 
+    it('updates thumbnails on existing record when previously empty', () => {
+      const store = createShareStore(dbPath)
+      // First save without thumbnails
+      const id1 = store.save(sampleParams)
+      const result1 = store.get(id1)!
+      expect(result1.bookThumb).toBe('')
+      expect(result1.musicThumb).toBe('')
+      expect(result1.movieThumb).toBe('')
+
+      // Second save with same params but with thumbnails
+      const id2 = store.save({
+        ...sampleParams,
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: 'https://example.com/music.jpg',
+        movieThumb: 'https://example.com/movie.jpg',
+      })
+
+      // Should return the same id (idempotent)
+      expect(id2).toBe(id1)
+
+      // Thumbnails should now be updated
+      const result2 = store.get(id2)!
+      expect(result2.bookThumb).toBe('https://example.com/book.jpg')
+      expect(result2.musicThumb).toBe('https://example.com/music.jpg')
+      expect(result2.movieThumb).toBe('https://example.com/movie.jpg')
+      store.close()
+    })
+
+    it('does not overwrite existing thumbnails with empty strings', () => {
+      const store = createShareStore(dbPath)
+      // Save with thumbnails
+      const id1 = store.save({
+        ...sampleParams,
+        bookThumb: 'https://example.com/book.jpg',
+        musicThumb: 'https://example.com/music.jpg',
+        movieThumb: 'https://example.com/movie.jpg',
+      })
+
+      // Save again without thumbnails
+      const id2 = store.save(sampleParams)
+      expect(id2).toBe(id1)
+
+      // Original thumbnails should be preserved
+      const result = store.get(id2)!
+      expect(result.bookThumb).toBe('https://example.com/book.jpg')
+      expect(result.musicThumb).toBe('https://example.com/music.jpg')
+      expect(result.movieThumb).toBe('https://example.com/movie.jpg')
+      store.close()
+    })
+
     it('defaults thumbnails to empty string when not provided', () => {
       const store = createShareStore(dbPath)
       const id = store.save(sampleParams)

--- a/src/server/share-store.ts
+++ b/src/server/share-store.ts
@@ -155,7 +155,15 @@ export function createShareStore(
   `)
 
   const selectByHashStmt = db.prepare(`
-    SELECT id FROM shares WHERE params_hash = ?
+    SELECT id, book_thumb, music_thumb, movie_thumb FROM shares WHERE params_hash = ?
+  `)
+
+  const updateThumbsStmt = db.prepare(`
+    UPDATE shares
+    SET book_thumb = CASE WHEN book_thumb = '' AND @bookThumb != '' THEN @bookThumb ELSE book_thumb END,
+        music_thumb = CASE WHEN music_thumb = '' AND @musicThumb != '' THEN @musicThumb ELSE music_thumb END,
+        movie_thumb = CASE WHEN movie_thumb = '' AND @movieThumb != '' THEN @movieThumb ELSE movie_thumb END
+    WHERE id = @id
   `)
 
   const countStmt = db.prepare(`SELECT COUNT(*) as cnt FROM shares`)
@@ -188,8 +196,31 @@ export function createShareStore(
     const hash = computeParamsHash(params)
 
     // Return existing ID if the same params were already saved
-    const existing = selectByHashStmt.get(hash) as { id: string } | undefined
+    const existing = selectByHashStmt.get(hash) as
+      | {
+          id: string
+          book_thumb: string
+          music_thumb: string
+          movie_thumb: string
+        }
+      | undefined
     if (existing) {
+      // Update thumbnails if they were previously empty
+      const bookThumb = params.bookThumb ?? ''
+      const musicThumb = params.musicThumb ?? ''
+      const movieThumb = params.movieThumb ?? ''
+      if (
+        (existing.book_thumb === '' && bookThumb !== '') ||
+        (existing.music_thumb === '' && musicThumb !== '') ||
+        (existing.movie_thumb === '' && movieThumb !== '')
+      ) {
+        updateThumbsStmt.run({
+          bookThumb,
+          musicThumb,
+          movieThumb,
+          id: existing.id,
+        })
+      }
       return existing.id
     }
 


### PR DESCRIPTION
## 問題

ギャラリーページで一部のカードがサムネイルではなく「タップして見る」と表示されていた。

## 原因

`ShareButtons` の `useEffect` がマウント直後に `createShortUrl` を呼び出すが、この時点では `useWorkFetch` がまだ非同期でデータ取得中のため、サムネイルURLがすべて空文字の状態でシェアレコードが保存されていた。

さらに `computeParamsHash` はサムネイルURLを含まないため、後からサムネイルが揃った状態で再送しても、同一ハッシュの既存レコード（サムネイル空）のIDが返され、更新されなかった。

## 修正内容

### クライアント側（ShareButtons.tsx）
- `useEffect` 内で、選択された各カテゴリのサムネイルが揃うまで `createShortUrl` の呼び出しを遅延
- IDがあるのにサムネイルが空のカテゴリがある場合は待機する

### サーバー側（share-store.ts）
- `save` で既存レコードが見つかった場合、サムネイルが空なら新しい値でUPDATEするロジックを追加
- 既にサムネイルがある場合は上書きしない（空→値の方向のみ更新）

### 既存データの修復
- `88XJNQKv`（テーマ「きいろ」）のサムネイルをAPIから取得して手動修復済み