### PR TITLE
refactor: ページヘッダー(グラデーション装飾)の共通コンポーネント化

### DIFF
--- a/src/components/PageHeader.test.tsx
+++ b/src/components/PageHeader.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import PageHeader from './PageHeader'
+
+describe('PageHeader', () => {
+  it('renders the title', () => {
+    render(<PageHeader title="My No.1s" />)
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'My No.1s' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders subtitle when provided', () => {
+    render(
+      <PageHeader
+        title="みんなのNo.1s"
+        subtitle="みんなが選んだお気に入りの作品たち"
+      />,
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'みんなのNo.1s' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('みんなが選んだお気に入りの作品たち'),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render subtitle element when not provided', () => {
+    const { container } = render(<PageHeader title="My No.1s" />)
+    expect(container.querySelector('p')).toBeNull()
+  })
+
+  it('renders decorative gradient lines', () => {
+    const { container } = render(<PageHeader title="Test" />)
+    const lines = container.querySelectorAll('.h-0\\.5')
+    expect(lines).toHaveLength(2)
+  })
+})

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,46 @@
+type Props = {
+  title: string
+  subtitle?: string
+}
+
+export default function PageHeader({ title, subtitle }: Props) {
+  return (
+    <div className="text-center">
+      <div
+        className="mx-auto mb-2 h-0.5 w-16 rounded-full"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
+        }}
+      />
+      <h1
+        className="text-xl font-extrabold sm:text-2xl"
+        style={{
+          fontFamily: 'var(--font-display)',
+          background:
+            'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          backgroundClip: 'text',
+        }}
+      >
+        {title}
+      </h1>
+      {subtitle && (
+        <p
+          className="mt-1 text-sm"
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
+          {subtitle}
+        </p>
+      )}
+      <div
+        className="mx-auto mt-2 h-0.5 w-16 rounded-full"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -9,6 +9,7 @@ import WorkCard from './WorkCard'
 import { useWorkFetch } from '../hooks/useWorkFetch'
 import { usePreGeneratedImage } from '../hooks/usePreGeneratedImage'
 import DataCredits from './DataCredits'
+import PageHeader from './PageHeader'
 
 type Top3Params = {
   theme: string
@@ -76,36 +77,7 @@ export default function Top3Content({ params, existingShareId }: Props) {
       }}
     >
       <div className="mx-auto max-w-4xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
-        {/* Header with decorative line */}
-        <div className="text-center">
-          <div
-            className="mx-auto mb-2 h-0.5 w-16 rounded-full"
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
-            }}
-          />
-          <h1
-            className="text-xl font-extrabold sm:text-2xl"
-            style={{
-              fontFamily: 'var(--font-display)',
-              background:
-                'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-              backgroundClip: 'text',
-            }}
-          >
-            My No.1s
-          </h1>
-          <div
-            className="mx-auto mt-2 h-0.5 w-16 rounded-full"
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
-            }}
-          />
-        </div>
+        <PageHeader title="My No.1s" />
 
         {/* Theme display with decorative quotes via CSS pseudo-elements */}
         {params.theme && (

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import ErrorMessage from '../components/ErrorMessage'
 import GalleryCard from '../components/GalleryCard'
 import DataCredits from '../components/DataCredits'
+import PageHeader from '../components/PageHeader'
 import { useGallery } from '../hooks/useGallery'
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver'
 
@@ -20,42 +21,10 @@ export default function GalleryPage() {
       }}
     >
       <div className="mx-auto max-w-5xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
-        {/* Header */}
-        <div className="text-center">
-          <div
-            className="mx-auto mb-2 h-0.5 w-16 rounded-full"
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
-            }}
-          />
-          <h1
-            className="text-xl font-extrabold sm:text-2xl"
-            style={{
-              fontFamily: 'var(--font-display)',
-              background:
-                'linear-gradient(135deg, var(--color-primary-dark), var(--color-primary))',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-              backgroundClip: 'text',
-            }}
-          >
-            みんなのNo.1s
-          </h1>
-          <p
-            className="mt-1 text-sm"
-            style={{ color: 'var(--color-text-secondary)' }}
-          >
-            みんなが選んだお気に入りの作品たち
-          </p>
-          <div
-            className="mx-auto mt-2 h-0.5 w-16 rounded-full"
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, var(--color-primary), transparent)',
-            }}
-          />
-        </div>
+        <PageHeader
+          title="みんなのNo.1s"
+          subtitle="みんなが選んだお気に入りの作品たち"
+        />
 
         {/* Loading */}
         {loading && (


### PR DESCRIPTION
## 概要

`Top3Content.tsx` と `GalleryPage.tsx` で重複していたグラデーション装飾付きページヘッダーを `<PageHeader title subtitle? />` コンポーネントとして抽出しました。

## 変更内容

- **新規**: `src/components/PageHeader.tsx` — 共通ヘッダーコンポーネント
- **新規**: `src/components/PageHeader.test.tsx` — テスト (4件)
- **変更**: `src/components/Top3Content.tsx` — 重複マークアップを `<PageHeader>` に置き換え
- **変更**: `src/pages/GalleryPage.tsx` — 重複マークアップを `<PageHeader>` に置き換え

## 削減量

約25行の重複コードを削減。

closes #203