### PR TITLE
refactor: Pill型ボタンスタイルをPillLinkButtonコンポーネントに共通化

### DIFF
--- a/src/components/PillLinkButton.test.tsx
+++ b/src/components/PillLinkButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import PillLinkButton from './PillLinkButton'
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>)
+
+describe('PillLinkButton', () => {
+  it('renders children as link text', () => {
+    renderWithRouter(<PillLinkButton to="/">テスト</PillLinkButton>)
+    expect(screen.getByRole('link', { name: 'テスト' })).toBeInTheDocument()
+  })
+
+  it('links to the specified path', () => {
+    renderWithRouter(<PillLinkButton to="/gallery">ギャラリー</PillLinkButton>)
+    expect(screen.getByRole('link', { name: 'ギャラリー' })).toHaveAttribute(
+      'href',
+      '/gallery',
+    )
+  })
+
+  it('defaults to primary color', () => {
+    const { container } = renderWithRouter(
+      <PillLinkButton to="/">Primary</PillLinkButton>,
+    )
+    const button = container.querySelector('a')
+    expect(button).toBeInTheDocument()
+  })
+
+  it('accepts secondary color', () => {
+    renderWithRouter(
+      <PillLinkButton to="/" color="secondary">
+        Secondary
+      </PillLinkButton>,
+    )
+    expect(screen.getByRole('link', { name: 'Secondary' })).toBeInTheDocument()
+  })
+})

--- a/src/components/PillLinkButton.tsx
+++ b/src/components/PillLinkButton.tsx
@@ -1,0 +1,54 @@
+import { type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import Button from '@mui/material/Button'
+
+type PillColor = 'primary' | 'secondary'
+
+type Props = {
+  to: string
+  color?: PillColor
+  children: ReactNode
+}
+
+const colorMap: Record<PillColor, { main: string; dark: string }> = {
+  primary: {
+    main: 'var(--color-primary)',
+    dark: 'var(--color-primary-dark)',
+  },
+  secondary: {
+    main: 'var(--color-secondary)',
+    dark: 'var(--color-secondary-dark)',
+  },
+}
+
+export default function PillLinkButton({
+  to,
+  color = 'primary',
+  children,
+}: Props) {
+  const { main, dark } = colorMap[color]
+
+  return (
+    <Button
+      component={Link}
+      to={to}
+      variant="outlined"
+      sx={{
+        borderRadius: '9999px',
+        px: 4,
+        py: 1,
+        borderColor: main,
+        color: main,
+        fontWeight: 600,
+        transition: 'all 0.2s',
+        '&:hover': {
+          borderColor: dark,
+          backgroundColor: main,
+          color: '#fff',
+        },
+      }}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import Button from '@mui/material/Button'
 import { buildEditUrl } from '../utils/url-params'
+import PillLinkButton from './PillLinkButton'
 import ErrorMessage from './ErrorMessage'
 import ShareButtons from './ShareButtons'
 import Top3Image from './Top3Image'
@@ -149,48 +150,12 @@ export default function Top3Content({ params, existingShareId }: Props) {
         </div>
 
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-          <Button
-            component={Link}
-            to={buildEditUrl(params)}
-            variant="outlined"
-            sx={{
-              borderRadius: '9999px',
-              px: 4,
-              py: 1,
-              borderColor: 'var(--color-primary)',
-              color: 'var(--color-primary)',
-              fontWeight: 600,
-              transition: 'all 0.2s',
-              '&:hover': {
-                borderColor: 'var(--color-primary-dark)',
-                backgroundColor: 'var(--color-primary)',
-                color: '#fff',
-              },
-            }}
-          >
+          <PillLinkButton to={buildEditUrl(params)}>
             ← トップページに戻る
-          </Button>
-          <Button
-            component={Link}
-            to="/gallery"
-            variant="outlined"
-            sx={{
-              borderRadius: '9999px',
-              px: 4,
-              py: 1,
-              borderColor: 'var(--color-secondary)',
-              color: 'var(--color-secondary)',
-              fontWeight: 600,
-              transition: 'all 0.2s',
-              '&:hover': {
-                borderColor: 'var(--color-secondary-dark)',
-                backgroundColor: 'var(--color-secondary)',
-                color: '#fff',
-              },
-            }}
-          >
+          </PillLinkButton>
+          <PillLinkButton to="/gallery" color="secondary">
             🎨 みんなのNo.1s
-          </Button>
+          </PillLinkButton>
         </div>
       </div>
 

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -5,6 +5,7 @@ import ErrorMessage from '../components/ErrorMessage'
 import GalleryCard from '../components/GalleryCard'
 import DataCredits from '../components/DataCredits'
 import PageHeader from '../components/PageHeader'
+import PillLinkButton from '../components/PillLinkButton'
 import { useGallery } from '../hooks/useGallery'
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver'
 
@@ -105,27 +106,7 @@ export default function GalleryPage() {
 
         {/* Navigation */}
         <div className="mt-8 text-center">
-          <Button
-            component={Link}
-            to="/"
-            variant="outlined"
-            sx={{
-              borderRadius: '9999px',
-              px: 4,
-              py: 1,
-              borderColor: 'var(--color-primary)',
-              color: 'var(--color-primary)',
-              fontWeight: 600,
-              transition: 'all 0.2s',
-              '&:hover': {
-                borderColor: 'var(--color-primary-dark)',
-                backgroundColor: 'var(--color-primary)',
-                color: '#fff',
-              },
-            }}
-          >
-            ← Top3を作成する
-          </Button>
+          <PillLinkButton to="/">← Top3を作成する</PillLinkButton>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要

Closes #204

角丸 + hover時fill の Pill型ボタン sx パターンが3箇所で重複していたのを `PillLinkButton` コンポーネントに抽出しました。

## 変更内容

### 新規
- `src/components/PillLinkButton.tsx` — `to`, `color`(primary/secondary), `children` を受け取る共通Pillボタン
- `src/components/PillLinkButton.test.tsx` — ユニットテスト (4 tests)

### 修正
- `src/components/Top3Content.tsx` — 2箇所の pill sx を `PillLinkButton` に置き換え
- `src/pages/GalleryPage.tsx` — 1箇所の pill sx を `PillLinkButton` に置き換え

## チェック
- [x] `npm run lint` ✅
- [x] `npm run format:check` ✅
- [x] `npm run typecheck` ✅
- [x] `npm run test` ✅ (542 tests passed)