### PR TITLE
refactor: ogp.ts の fetchWorkTitle() カテゴリ分岐をデータ駆動化

### DIFF
--- a/src/server/ogp.test.ts
+++ b/src/server/ogp.test.ts
@@ -68,11 +68,11 @@ describe('buildOgDescription', () => {
 
   it('joins work titles with slash separator', () => {
     const works = [
-      { title: '1Q84', category: '📚Book' },
+      { title: '1Q84', category: '📖Book' },
       { title: 'Bohemian Rhapsody', category: '🎵Music' },
     ]
     expect(buildOgDescription(works)).toBe(
-      '📚Book: 1Q84 / 🎵Music: Bohemian Rhapsody',
+      '📖Book: 1Q84 / 🎵Music: Bohemian Rhapsody',
     )
   })
 
@@ -83,12 +83,12 @@ describe('buildOgDescription', () => {
 
   it('handles all three works', () => {
     const works = [
-      { title: '1Q84', category: '📚Book' },
+      { title: '1Q84', category: '📖Book' },
       { title: 'Shape of You', category: '🎵Music' },
       { title: 'Inception', category: '🎬Movie' },
     ]
     expect(buildOgDescription(works)).toBe(
-      '📚Book: 1Q84 / 🎵Music: Shape of You / 🎬Movie: Inception',
+      '📖Book: 1Q84 / 🎵Music: Shape of You / 🎬Movie: Inception',
     )
   })
 })
@@ -97,7 +97,7 @@ describe('buildMetaTags', () => {
   it('generates all required OGP and Twitter meta tags', () => {
     const result = buildMetaTags({
       title: 'テスト | My No.1s',
-      description: '📚Book: 1Q84',
+      description: '📖Book: 1Q84',
       url: 'https://example.com/my-no1s?theme=test',
     })
 
@@ -211,7 +211,7 @@ describe('injectOgpTags', () => {
       params,
     )
 
-    expect(result).toContain('📚Book: 1Q84')
+    expect(result).toContain('📖Book: 1Q84')
     expect(getBookById).toHaveBeenCalledWith('test-key', 'book1')
   })
 
@@ -270,7 +270,7 @@ describe('injectOgpTags', () => {
       params,
     )
 
-    expect(result).toContain('📚Book: 1Q84')
+    expect(result).toContain('📖Book: 1Q84')
     expect(result).toContain('🎵Music: Shape of You')
     expect(result).toContain('🎬Movie: Inception')
   })

--- a/src/server/ogp.ts
+++ b/src/server/ogp.ts
@@ -1,5 +1,10 @@
 import { getBookById } from '../services/google-books.ts'
-import type { SearchResultItem } from '../types/common.ts'
+import {
+  CATEGORY_ICONS,
+  CATEGORY_LABELS_EN,
+  CATEGORIES,
+} from '../constants/category.ts'
+import type { MediaCategory, SearchResultItem } from '../types/common.ts'
 
 const MAX_THEME_LENGTH = 50
 const DEFAULT_SITE_NAME = 'My No.1s'
@@ -54,33 +59,48 @@ export function buildMetaTags(options: {
   return tags.join('\n    ')
 }
 
+type CategoryConfig = {
+  envKey: string
+  getById: (
+    apiKey: string,
+    id: string,
+  ) => Promise<{ ok: boolean; data?: SearchResultItem }>
+}
+
+const CATEGORY_CONFIG: Record<MediaCategory, () => Promise<CategoryConfig>> = {
+  book: async () => ({
+    envKey: 'GOOGLE_BOOKS_API_KEY',
+    getById: getBookById,
+  }),
+  music: async () => {
+    const { getMusicById } = await import('../services/lastfm.ts')
+    return { envKey: 'LASTFM_API_KEY', getById: getMusicById }
+  },
+  movie: async () => {
+    const { getMovieById } = await import('../services/tmdb.ts')
+    return { envKey: 'TMDB_API_KEY', getById: getMovieById }
+  },
+}
+
+function buildCategoryLabel(category: MediaCategory): string {
+  return `${CATEGORY_ICONS[category]}${CATEGORY_LABELS_EN[category]}`
+}
+
 async function fetchWorkTitle(
-  category: 'book' | 'music' | 'movie',
+  category: MediaCategory,
   id: string,
 ): Promise<WorkInfo | null> {
-  const categoryLabels = { book: '📚Book', music: '🎵Music', movie: '🎬Movie' }
-
   try {
-    let result: { ok: boolean; data?: SearchResultItem }
+    const { envKey, getById } = await CATEGORY_CONFIG[category]()
+    const apiKey = process.env[envKey] ?? ''
+    if (!apiKey) return null
 
-    if (category === 'book') {
-      const apiKey = process.env['GOOGLE_BOOKS_API_KEY'] ?? ''
-      if (!apiKey) return null
-      result = await getBookById(apiKey, id)
-    } else if (category === 'music') {
-      const apiKey = process.env['LASTFM_API_KEY'] ?? ''
-      if (!apiKey) return null
-      const { getMusicById } = await import('../services/lastfm.ts')
-      result = await getMusicById(apiKey, id)
-    } else {
-      const apiKey = process.env['TMDB_API_KEY'] ?? ''
-      if (!apiKey) return null
-      const { getMovieById } = await import('../services/tmdb.ts')
-      result = await getMovieById(apiKey, id)
-    }
-
+    const result = await getById(apiKey, id)
     if (result.ok && result.data) {
-      return { title: result.data.title, category: categoryLabels[category] }
+      return {
+        title: result.data.title,
+        category: buildCategoryLabel(category),
+      }
     }
   } catch (e) {
     console.error(`[ogp] Failed to fetch ${category} (id: ${id}):`, e)
@@ -99,45 +119,23 @@ export async function injectOgpTags(
   const musicId = searchParams.get('music') ?? ''
   const movieId = searchParams.get('movie') ?? ''
 
-  const works: WorkInfo[] = []
+  const idByCategory: Record<MediaCategory, string> = {
+    book: bookId,
+    music: musicId,
+    movie: movieId,
+  }
 
   // Fetch work titles in parallel
-  const fetchPromises: Promise<void>[] = []
-
-  if (bookId) {
-    fetchPromises.push(
-      fetchWorkTitle('book', bookId).then((w) => {
-        if (w) works.push(w)
-      }),
-    )
-  }
-  if (musicId) {
-    fetchPromises.push(
-      fetchWorkTitle('music', musicId).then((w) => {
-        if (w) works.push(w)
-      }),
-    )
-  }
-  if (movieId) {
-    fetchPromises.push(
-      fetchWorkTitle('movie', movieId).then((w) => {
-        if (w) works.push(w)
-      }),
-    )
-  }
+  const fetchPromises = CATEGORIES.filter((cat) => idByCategory[cat]).map(
+    (cat) => fetchWorkTitle(cat, idByCategory[cat]),
+  )
 
   // Wait with timeout to avoid blocking crawlers for too long
-  await Promise.race([
-    Promise.allSettled(fetchPromises),
-    new Promise((resolve) => setTimeout(resolve, 3000)),
-  ])
-
-  // Sort works in consistent order: book, music, movie
-  const categoryOrder = ['📚Book', '🎵Music', '🎬Movie']
-  works.sort(
-    (a, b) =>
-      categoryOrder.indexOf(a.category) - categoryOrder.indexOf(b.category),
+  const timeout = new Promise<(WorkInfo | null)[]>((resolve) =>
+    setTimeout(() => resolve(fetchPromises.map(() => null)), 3000),
   )
+  const results = await Promise.race([Promise.all(fetchPromises), timeout])
+  const works = results.filter((w): w is WorkInfo => w !== null)
 
   const title = buildOgTitle(theme)
   const description = buildOgDescription(works)


### PR DESCRIPTION
## 概要

`fetchWorkTitle()` の3分岐 if/else をデータ駆動の設定マップに変換し、重複を解消。

## 変更内容

### `src/server/ogp.ts`
- **`CATEGORY_CONFIG` マップ導入**: カテゴリごとの `envKey` と `getById` 関数をデータとして定義し、if/else 分岐を排除
- **`buildCategoryLabel()` 関数追加**: `constants/category.ts` の `CATEGORY_ICONS` + `CATEGORY_LABELS_EN` からラベルを生成（ハードコード排除）
- **並列 fetch を `Promise.all` + filter に書き換え**: mutable array への `.then()` push パターンを解消
- **ソート処理の除去**: `CATEGORIES` 配列の順序で fetch するため不要に

### `src/server/ogp.test.ts`
- Book アイコンを `📚` → `📖` に更新（`constants/category.ts` の `CATEGORY_ICONS` に統一）

## 対応 Issue

Closes #207