### PR TITLE
refactor: useMergedRef() hook の抽出 (ref マージボイラープレート解消)

### DIFF
--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import Button from '@mui/material/Button'
 import { buildEditUrl } from '../utils/url-params'
@@ -9,6 +9,7 @@ import Top3Image from './Top3Image'
 import WorkCard from './WorkCard'
 import { useWorkFetch } from '../hooks/useWorkFetch'
 import { usePreGeneratedImage } from '../hooks/usePreGeneratedImage'
+import { useMergedRef } from '../hooks/useMergedRef'
 import DataCredits from './DataCredits'
 import PageHeader from './PageHeader'
 
@@ -29,11 +30,7 @@ export default function Top3Content({ params, existingShareId }: Props) {
   const [captureElement, setCaptureElement] = useState<HTMLDivElement | null>(
     null,
   )
-  const captureRefCallback = useCallback((node: HTMLDivElement | null) => {
-    ;(captureRef as React.MutableRefObject<HTMLDivElement | null>).current =
-      node
-    setCaptureElement(node)
-  }, [])
+  const captureRefCallback = useMergedRef(captureRef, setCaptureElement)
 
   const book = useWorkFetch('book', params.bookId)
   const music = useWorkFetch('music', params.musicId)

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -6,20 +6,17 @@ import type { SearchResultItem, MediaCategory } from '../types/common'
 import { IMAGE_SIZE, HALF, SEP } from '../constants/image-layout'
 import { useImageCapture } from '../hooks/useImageCapture'
 import { useLayoutSwap } from '../hooks/useLayoutSwap'
+import { useMergedRef } from '../hooks/useMergedRef'
 import { ImageSlot } from './ImageSlot'
 import { StatusSnackbar } from './StatusSnackbar'
 import { LayoutSelector } from './LayoutSelector'
-
-type CaptureRefProp =
-  | React.RefObject<HTMLDivElement | null>
-  | ((node: HTMLDivElement | null) => void)
 
 type Top3ImageProps = {
   theme: string
   book: SearchResultItem | null
   music: SearchResultItem | null
   movie: SearchResultItem | null
-  captureRef?: CaptureRefProp
+  captureRef?: React.Ref<HTMLDivElement>
 }
 
 function Top3Image({
@@ -41,20 +38,9 @@ function Top3Image({
     handleDownload,
   } = useImageCapture(theme)
 
-  // Use a callback ref to sync both internal and external refs
-  const captureRefCallback = React.useCallback(
-    (node: HTMLDivElement | null) => {
-      const mutableInternalRef =
-        internalCaptureRef as React.MutableRefObject<HTMLDivElement | null>
-      mutableInternalRef.current = node
-      if (typeof externalCaptureRef === 'function') {
-        externalCaptureRef(node)
-      } else if (externalCaptureRef && 'current' in externalCaptureRef) {
-        // Assign via Object.assign to avoid lint immutability error on props
-        Object.assign(externalCaptureRef, { current: node })
-      }
-    },
-    [internalCaptureRef, externalCaptureRef],
+  const captureRefCallback = useMergedRef(
+    internalCaptureRef,
+    externalCaptureRef,
   )
 
   const { layout, handleLayoutChange } = useLayoutSwap()

--- a/src/hooks/useMergedRef.test.ts
+++ b/src/hooks/useMergedRef.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import { useMergedRef } from './useMergedRef'
+
+describe('useMergedRef', () => {
+  it('updates a RefObject', () => {
+    const ref = createRef<HTMLDivElement>()
+    const { result } = renderHook(() => useMergedRef(ref))
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(ref.current).toBe(node)
+  })
+
+  it('calls a callback ref', () => {
+    const callbackRef = vi.fn()
+    const { result } = renderHook(() => useMergedRef(callbackRef))
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+  })
+
+  it('merges multiple refs', () => {
+    const refObject = createRef<HTMLDivElement>()
+    const callbackRef = vi.fn()
+    const { result } = renderHook(() => useMergedRef(refObject, callbackRef))
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(refObject.current).toBe(node)
+    expect(callbackRef).toHaveBeenCalledWith(node)
+  })
+
+  it('handles null refs gracefully', () => {
+    const callbackRef = vi.fn()
+    const { result } = renderHook(() =>
+      useMergedRef(null, undefined, callbackRef),
+    )
+
+    const node = document.createElement('div')
+    result.current(node)
+
+    expect(callbackRef).toHaveBeenCalledWith(node)
+  })
+
+  it('sets node to null on unmount', () => {
+    const refObject = createRef<HTMLDivElement>()
+    const callbackRef = vi.fn()
+    const { result } = renderHook(() => useMergedRef(refObject, callbackRef))
+
+    const node = document.createElement('div')
+    result.current(node)
+    result.current(null)
+
+    expect(refObject.current).toBeNull()
+    expect(callbackRef).toHaveBeenCalledWith(null)
+  })
+
+  it('returns a stable callback when refs do not change', () => {
+    const ref = createRef<HTMLDivElement>()
+    const { result, rerender } = renderHook(() => useMergedRef(ref))
+
+    const first = result.current
+    rerender()
+
+    expect(result.current).toBe(first)
+  })
+})

--- a/src/hooks/useMergedRef.ts
+++ b/src/hooks/useMergedRef.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react'
+import type { Ref, RefCallback } from 'react'
+
+type MergeableRef<T> = Ref<T> | undefined
+
+function setRef<T>(ref: MergeableRef<T>, value: T | null): void {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref && 'current' in ref) {
+    ;(ref as React.MutableRefObject<T | null>).current = value
+  }
+}
+
+export function useMergedRef<T>(
+  ...refs: ReadonlyArray<MergeableRef<T>>
+): RefCallback<T> {
+  return useCallback(
+    (node: T | null) => {
+      for (const ref of refs) {
+        setRef(ref, node)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refs,
+  )
+}


### PR DESCRIPTION
## 概要

Closes #208

複数 ref をマージするボイラープレートコードを `useMergedRef()` カスタムhookに抽出。

## 変更内容

### 新規ファイル
- **`src/hooks/useMergedRef.ts`** — `RefObject`, callback ref, `null`/`undefined` を受け取り、単一の安定した callback ref を返すhook
- **`src/hooks/useMergedRef.test.ts`** — 6テスト（RefObject / callback ref / 混合 / null処理 / unmount / 安定性）

### リファクタリング
- **`Top3Image.tsx`** — 12行の `Object.assign` ハック → `useMergedRef(internalCaptureRef, externalCaptureRef)` 1行に
- **`Top3Content.tsx`** — `MutableRefObject` キャスト + 手動コールバック → `useMergedRef(captureRef, setCaptureElement)` 1行に

## チェック結果
- ✅ lint (0 errors)
- ✅ format
- ✅ typecheck
- ✅ test (564 passed)