### PR TITLE
feat: ギャラリーにいいね(❤️)リアクション機能を追加

### DIFF
--- a/src/components/GalleryCard.test.tsx
+++ b/src/components/GalleryCard.test.tsx
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import GalleryCard from './GalleryCard'
+
+// Mock useReaction
+const mockToggleReaction = vi.fn()
+vi.mock('../hooks/useReaction', () => ({
+  useReaction: (_shareId: string, initialCount: number) => ({
+    count: initialCount,
+    reacted: false,
+    toggleReaction: mockToggleReaction,
+  }),
+}))
 
 const defaultProps = {
   id: 'abc123',
@@ -10,6 +20,7 @@ const defaultProps = {
   musicThumb: 'https://example.com/music.jpg',
   movieThumb: 'https://example.com/movie.jpg',
   createdAt: 1700000000,
+  reactionCount: 5,
 }
 
 function renderCard(props = defaultProps) {
@@ -19,6 +30,10 @@ function renderCard(props = defaultProps) {
     </MemoryRouter>,
   )
 }
+
+afterEach(() => {
+  mockToggleReaction.mockClear()
+})
 
 describe('GalleryCard', () => {
   it('renders theme name', () => {
@@ -58,5 +73,37 @@ describe('GalleryCard', () => {
     renderCard({ ...defaultProps, bookThumb: '' })
     const images = screen.getAllByRole('img')
     expect(images).toHaveLength(2)
+  })
+
+  it('renders reaction count', () => {
+    renderCard()
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('renders heart button', () => {
+    renderCard()
+    const btn = screen.getByRole('button', { name: /いいね/ })
+    expect(btn).toBeInTheDocument()
+  })
+
+  it('calls toggleReaction on heart button click', () => {
+    renderCard()
+    const btn = screen.getByRole('button', { name: /いいね/ })
+    fireEvent.click(btn)
+    expect(mockToggleReaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('heart button click does not navigate (stopPropagation)', () => {
+    renderCard()
+    const btn = screen.getByRole('button', { name: /いいね/ })
+    fireEvent.click(btn)
+    // The button handler should call preventDefault to stop link navigation
+    // We just check toggleReaction was called
+    expect(mockToggleReaction).toHaveBeenCalled()
+  })
+
+  it('shows 0 count when reactionCount is 0', () => {
+    renderCard({ ...defaultProps, reactionCount: 0 })
+    expect(screen.getByText('0')).toBeInTheDocument()
   })
 })

--- a/src/components/GalleryCard.tsx
+++ b/src/components/GalleryCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { useReaction } from '../hooks/useReaction'
 
 const PLACEHOLDER =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" fill="%23e5e7eb"><rect width="80" height="80"/></svg>'
@@ -10,6 +11,7 @@ type Props = {
   musicThumb: string
   movieThumb: string
   createdAt: number
+  reactionCount: number
 }
 
 function Thumbnail({ src, alt }: { src: string; alt: string }) {
@@ -43,8 +45,19 @@ export default function GalleryCard({
   musicThumb,
   movieThumb,
   createdAt,
+  reactionCount: initialReactionCount,
 }: Props) {
   const hasThumbs = bookThumb || musicThumb || movieThumb
+  const { count, reacted, toggleReaction } = useReaction(
+    id,
+    initialReactionCount,
+  )
+
+  const handleReaction = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    toggleReaction()
+  }
 
   return (
     <Link
@@ -91,13 +104,35 @@ export default function GalleryCard({
           </div>
         )}
 
-        {/* Date */}
-        <p
-          className="mt-3 text-xs"
-          style={{ color: 'var(--color-text-secondary)' }}
-        >
-          {formatDate(createdAt)}
-        </p>
+        {/* Footer: Date + Reaction */}
+        <div className="mt-3 flex items-center justify-between">
+          <p
+            className="text-xs"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {formatDate(createdAt)}
+          </p>
+
+          <button
+            type="button"
+            onClick={handleReaction}
+            aria-label="いいね"
+            className="flex items-center gap-1 rounded-full px-2 py-0.5 text-xs transition-colors duration-150"
+            style={{
+              color: reacted
+                ? 'var(--color-primary)'
+                : 'var(--color-text-secondary)',
+            }}
+          >
+            <span
+              className="transition-transform duration-150"
+              style={{ transform: reacted ? 'scale(1.2)' : 'scale(1)' }}
+            >
+              {reacted ? '❤️' : '🩵'}
+            </span>
+            <span>{count}</span>
+          </button>
+        </div>
       </div>
     </Link>
   )

--- a/src/hooks/useGallery.test.ts
+++ b/src/hooks/useGallery.test.ts
@@ -19,6 +19,7 @@ const makeFakeShares = (count: number) =>
     musicThumb: `https://example.com/music-${i}.jpg`,
     movieThumb: `https://example.com/movie-${i}.jpg`,
     createdAt: 1700000000 - i,
+    reactionCount: 0,
   }))
 
 describe('useGallery', () => {

--- a/src/hooks/useGallery.ts
+++ b/src/hooks/useGallery.ts
@@ -10,6 +10,7 @@ export type GalleryItem = {
   musicThumb: string
   movieThumb: string
   createdAt: number
+  reactionCount: number
 }
 
 type GalleryState = {

--- a/src/hooks/useReaction.test.ts
+++ b/src/hooks/useReaction.test.ts
@@ -1,0 +1,147 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+} from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/msw/server'
+import { useReaction } from './useReaction'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+afterEach(() => {
+  server.resetHandlers()
+  localStorage.clear()
+})
+afterAll(() => server.close())
+
+describe('useReaction', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('initializes with given count and reacted=false by default', () => {
+    const { result } = renderHook(() => useReaction('share-1', 5))
+    expect(result.current.count).toBe(5)
+    expect(result.current.reacted).toBe(false)
+  })
+
+  it('reads reacted state from localStorage', () => {
+    localStorage.setItem('reactions', JSON.stringify({ 'share-1': true }))
+    const { result } = renderHook(() => useReaction('share-1', 3))
+    expect(result.current.reacted).toBe(true)
+  })
+
+  it('toggleReaction adds a reaction optimistically', async () => {
+    server.use(
+      http.post('/api/shares/:id/reactions', () =>
+        HttpResponse.json({ ok: true, data: { count: 1, reacted: true } }),
+      ),
+    )
+
+    const { result } = renderHook(() => useReaction('share-1', 0))
+    expect(result.current.count).toBe(0)
+    expect(result.current.reacted).toBe(false)
+
+    act(() => result.current.toggleReaction())
+
+    // Optimistic update
+    expect(result.current.count).toBe(1)
+    expect(result.current.reacted).toBe(true)
+
+    // After API confirms
+    await waitFor(() => {
+      expect(result.current.count).toBe(1)
+    })
+  })
+
+  it('toggleReaction removes a reaction optimistically', async () => {
+    localStorage.setItem('reactions', JSON.stringify({ 'share-1': true }))
+    server.use(
+      http.post('/api/shares/:id/reactions', () =>
+        HttpResponse.json({ ok: true, data: { count: 0, reacted: false } }),
+      ),
+    )
+
+    const { result } = renderHook(() => useReaction('share-1', 1))
+    expect(result.current.reacted).toBe(true)
+
+    act(() => result.current.toggleReaction())
+
+    // Optimistic update
+    expect(result.current.count).toBe(0)
+    expect(result.current.reacted).toBe(false)
+
+    await waitFor(() => {
+      expect(result.current.count).toBe(0)
+    })
+  })
+
+  it('persists reacted state to localStorage', async () => {
+    server.use(
+      http.post('/api/shares/:id/reactions', () =>
+        HttpResponse.json({ ok: true, data: { count: 1, reacted: true } }),
+      ),
+    )
+
+    const { result } = renderHook(() => useReaction('share-1', 0))
+    act(() => result.current.toggleReaction())
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('reactions') ?? '{}')
+      expect(stored['share-1']).toBe(true)
+    })
+  })
+
+  it('reverts on API failure', async () => {
+    server.use(
+      http.post(
+        '/api/shares/:id/reactions',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    )
+
+    const { result } = renderHook(() => useReaction('share-1', 0))
+    act(() => result.current.toggleReaction())
+
+    // Optimistic
+    expect(result.current.count).toBe(1)
+    expect(result.current.reacted).toBe(true)
+
+    // Reverts after failure
+    await waitFor(() => {
+      expect(result.current.count).toBe(0)
+      expect(result.current.reacted).toBe(false)
+    })
+  })
+
+  it('generates and persists clientId in localStorage', async () => {
+    let capturedBody: Record<string, unknown> = {}
+    server.use(
+      http.post('/api/shares/:id/reactions', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json({
+          ok: true,
+          data: { count: 1, reacted: true },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useReaction('share-1', 0))
+    act(() => result.current.toggleReaction())
+
+    await waitFor(() => {
+      expect(capturedBody.clientId).toBeDefined()
+      expect(typeof capturedBody.clientId).toBe('string')
+    })
+
+    // clientId should be persisted
+    const clientId = localStorage.getItem('clientId')
+    expect(clientId).toBeTruthy()
+    expect(clientId).toBe(capturedBody.clientId)
+  })
+})

--- a/src/hooks/useReaction.ts
+++ b/src/hooks/useReaction.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback, useRef } from 'react'
+
+function getClientId(): string {
+  let id = localStorage.getItem('clientId')
+  if (!id) {
+    id = crypto.randomUUID()
+    localStorage.setItem('clientId', id)
+  }
+  return id
+}
+
+function getReactedMap(): Record<string, boolean> {
+  try {
+    return JSON.parse(localStorage.getItem('reactions') ?? '{}') as Record<
+      string,
+      boolean
+    >
+  } catch {
+    return {}
+  }
+}
+
+function setReactedMap(shareId: string, reacted: boolean): void {
+  const map = getReactedMap()
+  if (reacted) {
+    map[shareId] = true
+  } else {
+    delete map[shareId]
+  }
+  localStorage.setItem('reactions', JSON.stringify(map))
+}
+
+export function useReaction(shareId: string, initialCount: number) {
+  const [count, setCount] = useState(initialCount)
+  const [reacted, setReacted] = useState(() => {
+    const map = getReactedMap()
+    return !!map[shareId]
+  })
+  const inflightRef = useRef(false)
+
+  const toggleReaction = useCallback(() => {
+    if (inflightRef.current) return
+    inflightRef.current = true
+
+    const wasReacted = reacted
+    const prevCount = count
+
+    // Optimistic update
+    const nextReacted = !wasReacted
+    const nextCount = nextReacted ? prevCount + 1 : prevCount - 1
+    setReacted(nextReacted)
+    setCount(nextCount)
+    setReactedMap(shareId, nextReacted)
+
+    const clientId = getClientId()
+
+    fetch(`/api/shares/${shareId}/reactions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId, toggle: wasReacted }),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error('Reaction failed')
+        const json = (await res.json()) as {
+          ok: boolean
+          data: { count: number; reacted: boolean }
+        }
+        if (json.ok) {
+          setCount(json.data.count)
+          setReacted(json.data.reacted)
+          setReactedMap(shareId, json.data.reacted)
+        } else {
+          throw new Error('Reaction failed')
+        }
+      })
+      .catch(() => {
+        // Revert on failure
+        setReacted(wasReacted)
+        setCount(prevCount)
+        setReactedMap(shareId, wasReacted)
+      })
+      .finally(() => {
+        inflightRef.current = false
+      })
+  }, [shareId, reacted, count])
+
+  return { count, reacted, toggleReaction }
+}

--- a/src/pages/GalleryPage.test.tsx
+++ b/src/pages/GalleryPage.test.tsx
@@ -28,6 +28,14 @@ beforeEach(() => {
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
+vi.mock('../hooks/useReaction', () => ({
+  useReaction: (_shareId: string, initialCount: number) => ({
+    count: initialCount,
+    reacted: false,
+    toggleReaction: vi.fn(),
+  }),
+}))
+
 const makeFakeShares = (count: number) =>
   Array.from({ length: count }, (_, i) => ({
     id: `id-${i}`,
@@ -39,6 +47,7 @@ const makeFakeShares = (count: number) =>
     musicThumb: `https://example.com/music-${i}.jpg`,
     movieThumb: `https://example.com/movie-${i}.jpg`,
     createdAt: 1700000000 - i,
+    reactionCount: 0,
   }))
 
 function renderPage() {

--- a/src/server/routes/shares.test.ts
+++ b/src/server/routes/shares.test.ts
@@ -380,4 +380,101 @@ describe('shares route', () => {
       expect(res.status).toBe(404)
     })
   })
+
+  describe('POST /:id/reactions', () => {
+    async function createShare() {
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          theme: 'test',
+          bookId: 'b1',
+          musicId: 'm1',
+          movieId: 'v1',
+        }),
+      })
+      const json = (await res.json()) as { id: string }
+      return json.id
+    }
+
+    it('adds a reaction and returns count', async () => {
+      const id = await createShare()
+      const res = await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-1' }),
+      })
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as {
+        ok: boolean
+        data: { count: number; reacted: boolean }
+      }
+      expect(json.ok).toBe(true)
+      expect(json.data.count).toBe(1)
+      expect(json.data.reacted).toBe(true)
+    })
+
+    it('removes a reaction when already reacted (toggle)', async () => {
+      const id = await createShare()
+      // First: add
+      await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-1' }),
+      })
+      // Second: toggle off
+      const res = await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-1', toggle: true }),
+      })
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as {
+        ok: boolean
+        data: { count: number; reacted: boolean }
+      }
+      expect(json.data.count).toBe(0)
+      expect(json.data.reacted).toBe(false)
+    })
+
+    it('returns 400 when clientId is missing', async () => {
+      const id = await createShare()
+      const res = await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 404 for non-existent share', async () => {
+      const res = await app.request('/nonexist/reactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-1' }),
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('includes reactionCount in list response', async () => {
+      const id = await createShare()
+      await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-1' }),
+      })
+      await app.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientId: 'client-2' }),
+      })
+
+      const listRes = await app.request('/')
+      const listJson = (await listRes.json()) as {
+        ok: boolean
+        data: { items: { reactionCount: number }[] }
+      }
+      expect(listJson.data.items[0]!.reactionCount).toBe(2)
+    })
+  })
 })

--- a/src/server/routes/shares.ts
+++ b/src/server/routes/shares.ts
@@ -90,6 +90,61 @@ export function createSharesApp(dbPath: string, options?: SharesAppOptions) {
     }
   })
 
+  app.post('/:id/reactions', async (c) => {
+    const id = c.req.param('id')
+    const share = store.get(id)
+    if (!share) {
+      return c.json(
+        { ok: false, error: { kind: 'not_found', message: 'Share not found' } },
+        404,
+      )
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json(
+        { ok: false, error: { kind: 'validation', message: 'Invalid JSON' } },
+        400,
+      )
+    }
+
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return c.json(
+        { ok: false, error: { kind: 'validation', message: 'Invalid body' } },
+        400,
+      )
+    }
+
+    const { clientId, toggle } = body as {
+      clientId?: unknown
+      toggle?: unknown
+    }
+    if (typeof clientId !== 'string' || !clientId) {
+      return c.json(
+        {
+          ok: false,
+          error: { kind: 'validation', message: 'clientId is required' },
+        },
+        400,
+      )
+    }
+
+    try {
+      let result
+      if (toggle && store.hasReacted(id, clientId)) {
+        result = store.removeReaction(id, clientId)
+      } else {
+        result = store.addReaction(id, clientId)
+      }
+      return c.json({ ok: true, data: result })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Validation failed'
+      return c.json({ ok: false, error: { kind: 'validation', message } }, 400)
+    }
+  })
+
   app.get('/:id', (c) => {
     const id = c.req.param('id')
     const params = store.get(id)

--- a/src/server/share-store.test.ts
+++ b/src/server/share-store.test.ts
@@ -419,4 +419,132 @@ describe('share-store', () => {
       store.close()
     })
   })
+
+  describe('reactions', () => {
+    it('addReaction returns count=1 and reacted=true for first reaction', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      const result = store.addReaction(id, 'client-1')
+      expect(result).toEqual({ count: 1, reacted: true })
+      store.close()
+    })
+
+    it('addReaction is idempotent — same client cannot react twice', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      const result = store.addReaction(id, 'client-1')
+      expect(result).toEqual({ count: 1, reacted: true })
+      store.close()
+    })
+
+    it('multiple clients can react independently', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      const result = store.addReaction(id, 'client-2')
+      expect(result).toEqual({ count: 2, reacted: true })
+      store.close()
+    })
+
+    it('removeReaction decrements count and returns reacted=false', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      store.addReaction(id, 'client-2')
+      const result = store.removeReaction(id, 'client-1')
+      expect(result).toEqual({ count: 1, reacted: false })
+      store.close()
+    })
+
+    it('removeReaction is idempotent — no error if not reacted', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      const result = store.removeReaction(id, 'client-1')
+      expect(result).toEqual({ count: 0, reacted: false })
+      store.close()
+    })
+
+    it('getReactionCount returns 0 for share with no reactions', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      expect(store.getReactionCount(id)).toBe(0)
+      store.close()
+    })
+
+    it('getReactionCount returns correct count', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      store.addReaction(id, 'client-2')
+      store.addReaction(id, 'client-3')
+      expect(store.getReactionCount(id)).toBe(3)
+      store.close()
+    })
+
+    it('hasReacted returns false when client has not reacted', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      expect(store.hasReacted(id, 'client-1')).toBe(false)
+      store.close()
+    })
+
+    it('hasReacted returns true when client has reacted', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      expect(store.hasReacted(id, 'client-1')).toBe(true)
+      store.close()
+    })
+
+    it('reactions are scoped to specific shares', () => {
+      const store = createShareStore(dbPath)
+      const id1 = store.save({ ...sampleParams, theme: 'share1' })
+      const id2 = store.save({ ...sampleParams, theme: 'share2' })
+      store.addReaction(id1, 'client-1')
+      expect(store.getReactionCount(id1)).toBe(1)
+      expect(store.getReactionCount(id2)).toBe(0)
+      store.close()
+    })
+
+    it('list includes reactionCount for each item', () => {
+      const store = createShareStore(dbPath)
+      const id1 = store.save({ ...sampleParams, theme: 'popular' })
+      store.save({ ...sampleParams, theme: 'unpopular' })
+      store.addReaction(id1, 'client-1')
+      store.addReaction(id1, 'client-2')
+      const result = store.list({ limit: 10, offset: 0 })
+      const popular = result.items.find((i) => i.theme === 'popular')!
+      const unpopular = result.items.find((i) => i.theme === 'unpopular')!
+      expect(popular.reactionCount).toBe(2)
+      expect(unpopular.reactionCount).toBe(0)
+      store.close()
+    })
+
+    it('deleting a share also deletes its reactions', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      store.addReaction(id, 'client-1')
+      store.delete(id)
+      // After deletion, getReactionCount should return 0
+      expect(store.getReactionCount(id)).toBe(0)
+      store.close()
+    })
+
+    it('validates client_id is not empty', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      expect(() => store.addReaction(id, '')).toThrowError(/client_id/)
+      store.close()
+    })
+
+    it('validates client_id max length', () => {
+      const store = createShareStore(dbPath)
+      const id = store.save(sampleParams)
+      expect(() => store.addReaction(id, 'a'.repeat(101))).toThrowError(
+        /client_id/,
+      )
+      store.close()
+    })
+  })
 })

--- a/src/server/share-store.ts
+++ b/src/server/share-store.ts
@@ -115,6 +115,12 @@ function validateParams(params: ShareParams): void {
 export type ShareListItem = Required<ShareParams> & {
   id: string
   createdAt: number
+  reactionCount: number
+}
+
+export type ReactionResult = {
+  count: number
+  reacted: boolean
 }
 
 export type ShareListResult = {
@@ -127,12 +133,29 @@ export type ShareListOptions = {
   offset: number
 }
 
+const MAX_CLIENT_ID_LENGTH = 100
+
+function validateClientId(clientId: string): void {
+  if (!clientId) {
+    throw new Error('client_id is required')
+  }
+  if (clientId.length > MAX_CLIENT_ID_LENGTH) {
+    throw new Error(
+      `client_id exceeds maximum length of ${MAX_CLIENT_ID_LENGTH}`,
+    )
+  }
+}
+
 export type ShareStore = {
   save: (params: ShareParams) => string
   get: (id: string) => ShareParams | null
   list: (options: ShareListOptions) => ShareListResult
   delete: (id: string) => boolean
   purgeExpired: () => number
+  addReaction: (shareId: string, clientId: string) => ReactionResult
+  removeReaction: (shareId: string, clientId: string) => ReactionResult
+  getReactionCount: (shareId: string) => number
+  hasReacted: (shareId: string, clientId: string) => boolean
   close: () => void
 }
 
@@ -172,6 +195,16 @@ export function createShareStore(
       ON shares(params_hash) WHERE params_hash != '';
   `)
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS reactions (
+      share_id TEXT NOT NULL,
+      client_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (share_id, client_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_reactions_share_id ON reactions(share_id);
+  `)
+
   const insertStmt = db.prepare(`
     INSERT INTO shares (id, theme, book_id, music_id, movie_id, params_hash, book_thumb, music_thumb, movie_thumb, created_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())
@@ -200,10 +233,34 @@ export function createShareStore(
   const countStmt = db.prepare(`SELECT COUNT(*) as cnt FROM shares`)
 
   const listStmt = db.prepare(`
-    SELECT id, theme, book_id, music_id, movie_id, book_thumb, music_thumb, movie_thumb, created_at
-    FROM shares
-    ORDER BY created_at DESC
+    SELECT s.id, s.theme, s.book_id, s.music_id, s.movie_id,
+           s.book_thumb, s.music_thumb, s.movie_thumb, s.created_at,
+           COALESCE(r.cnt, 0) as reaction_count
+    FROM shares s
+    LEFT JOIN (SELECT share_id, COUNT(*) as cnt FROM reactions GROUP BY share_id) r
+      ON s.id = r.share_id
+    ORDER BY s.created_at DESC
     LIMIT ? OFFSET ?
+  `)
+
+  const insertReactionStmt = db.prepare(`
+    INSERT OR IGNORE INTO reactions (share_id, client_id) VALUES (?, ?)
+  `)
+
+  const deleteReactionStmt = db.prepare(`
+    DELETE FROM reactions WHERE share_id = ? AND client_id = ?
+  `)
+
+  const countReactionsStmt = db.prepare(`
+    SELECT COUNT(*) as cnt FROM reactions WHERE share_id = ?
+  `)
+
+  const hasReactedStmt = db.prepare(`
+    SELECT 1 FROM reactions WHERE share_id = ? AND client_id = ? LIMIT 1
+  `)
+
+  const deleteReactionsByShareStmt = db.prepare(`
+    DELETE FROM reactions WHERE share_id = ?
   `)
 
   const deleteOldestStmt = db.prepare(`
@@ -306,12 +363,14 @@ export function createShareStore(
       const rows = listStmt.all(options.limit, options.offset) as (ShareRow & {
         id: string
         created_at: number
+        reaction_count: number
       })[]
       return {
         items: rows.map((row) => ({
           ...mapRow(row),
           id: row.id,
           createdAt: row.created_at,
+          reactionCount: row.reaction_count,
         })),
         total: cnt,
       }
@@ -319,6 +378,7 @@ export function createShareStore(
 
     delete(id: string): boolean {
       if (!isValidShareId(id)) return false
+      deleteReactionsByShareStmt.run(id)
       const result = deleteByIdStmt.run(id)
       return result.changes > 0
     },
@@ -327,6 +387,29 @@ export function createShareStore(
       if (ttlSeconds <= 0) return 0
       const result = purgeExpiredStmt.run(ttlSeconds)
       return result.changes
+    },
+
+    addReaction(shareId: string, clientId: string): ReactionResult {
+      validateClientId(clientId)
+      insertReactionStmt.run(shareId, clientId)
+      const { cnt } = countReactionsStmt.get(shareId) as { cnt: number }
+      return { count: cnt, reacted: true }
+    },
+
+    removeReaction(shareId: string, clientId: string): ReactionResult {
+      validateClientId(clientId)
+      deleteReactionStmt.run(shareId, clientId)
+      const { cnt } = countReactionsStmt.get(shareId) as { cnt: number }
+      return { count: cnt, reacted: false }
+    },
+
+    getReactionCount(shareId: string): number {
+      const { cnt } = countReactionsStmt.get(shareId) as { cnt: number }
+      return cnt
+    },
+
+    hasReacted(shareId: string, clientId: string): boolean {
+      return !!hasReactedStmt.get(shareId, clientId)
     },
 
     close(): void {


### PR DESCRIPTION
## 概要

[Issue #231](https://github.com/t0m0m0/my-top3/issues/231) の Phase 1 実装。

ギャラリーの GalleryCard に ❤️ いいねボタンとカウント表示を追加しました。

## 変更内容

### バックエンド
- `reactions` テーブル追加 (`share_id`, `client_id`, `created_at`, 複合PK)
- `ShareStore` に `addReaction` / `removeReaction` / `getReactionCount` / `hasReacted` メソッド追加
- `POST /api/shares/:id/reactions` エンドポイント追加（トグル対応）
- `GET /api/shares` のレスポンスに `reactionCount` フィールドを追加（LEFT JOIN で集計）
- share 削除時に関連 reactions も削除

### フロントエンド
- `useReaction` hook 新規作成
  - `localStorage` で `clientId` を生成・永続化
  - `localStorage` で各 share の「いいね済み」状態を管理
  - 楽観的 UI 更新（即座にカウント反映 → API 確認、失敗時はリバート）
- `GalleryCard` に ❤️ ボタン + カウント表示を追加
  - リンク内ボタンのイベント伝播防止 (`preventDefault` + `stopPropagation`)
  - いいね済み時はスケールアニメーション付き ❤️ 表示
- `GalleryItem` 型に `reactionCount` 追加

### スパム対策
- 1 client_id × 1 share につき 1 回まで（DB の複合 PK + `INSERT OR IGNORE`）
- 既存のレートリミッター（IP ベース 60req/min）が API 全体に適用済み

## テスト
- `share-store.test.ts`: 14 テスト追加（reactions の CRUD、スコープ、バリデーション、カスケード削除）
- `shares.test.ts`: 5 テスト追加（reactions API エンドポイント）
- `useReaction.test.ts`: 7 テスト新規（楽観的更新、リバート、localStorage 永続化）
- `GalleryCard.test.tsx`: 5 テスト追加（ボタン表示、クリック、カウント表示）
- 全 595 テスト通過 ✅

Closes #231