### PR TITLE
feat: Pinterest風コレクションボードUI

### DIFF
--- a/mockups/plan-c-responsive.html
+++ b/mockups/plan-c-responsive.html
@@ -1,0 +1,1076 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Plan C Responsive: Collection Board — すきコレ</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@300;400;500;700;800&family=Zen+Maru+Gothic:wght@400;500;700;900&display=swap" rel="stylesheet">
+<style>
+/* ===== RESET ===== */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+html { font-size: 16px; -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+body {
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  color: #3d3530;
+  line-height: 1.6;
+  overflow-x: hidden;
+  background-color: #faf8f5;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='washi'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='6' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23washi)' opacity='0.04'/%3E%3C/svg%3E");
+}
+a { text-decoration: none; color: inherit; }
+
+/* ===== SCREEN NAV (demo only) ===== */
+.screen-nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+  background: rgba(74,55,40,0.95); backdrop-filter: blur(8px);
+  display: flex; justify-content: center; gap: 4px;
+  padding: 10px 16px;
+  flex-wrap: wrap;
+}
+.screen-nav a {
+  padding: 6px 16px; border-radius: 20px;
+  font-size: 13px; font-weight: 600; color: rgba(255,255,255,0.7);
+  transition: all 0.2s;
+}
+.screen-nav a:hover, .screen-nav a.active {
+  background: rgba(255,255,255,0.15); color: #fff;
+}
+
+/* ===== LAYOUT SHELL ===== */
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-top: 60px;
+}
+.screen-section {
+  min-height: 100vh;
+  padding: 40px 24px 80px;
+}
+.screen-section + .screen-section {
+  border-top: 1px solid rgba(200,190,175,0.3);
+}
+.screen-label {
+  display: inline-block;
+  background: linear-gradient(135deg, #4a3728, #6b5344);
+  color: #faf8f5;
+  padding: 6px 20px;
+  border-radius: 20px;
+  font-size: 13px; font-weight: 700;
+  margin-bottom: 32px;
+  letter-spacing: 0.5px;
+}
+
+/* ===== TYPOGRAPHY ===== */
+.heading-display { font-family: 'Zen Maru Gothic', serif; font-weight: 700; }
+.heading-brand { font-family: 'Zen Maru Gothic', serif; font-weight: 900; }
+
+/* ===== GRADIENTS ===== */
+.grad-warm { background: linear-gradient(135deg, #fde68a 0%, #fed7aa 50%, #fecaca 100%); }
+.grad-cool { background: linear-gradient(135deg, #c4b5fd 0%, #818cf8 50%, #6366f1 100%); }
+.grad-sky { background: linear-gradient(135deg, #7dd3fc 0%, #93c5fd 50%, #a78bfa 100%); }
+.grad-sunset { background: linear-gradient(135deg, #fda4af 0%, #fb923c 50%, #fbbf24 100%); }
+.grad-forest { background: linear-gradient(135deg, #6ee7b7 0%, #34d399 50%, #a3e635 100%); }
+.grad-night { background: linear-gradient(135deg, #1e1b4b 0%, #312e81 40%, #4f46e5 80%, #7c3aed 100%); }
+.grad-sakura { background: linear-gradient(135deg, #fce7f3 0%, #fbcfe8 50%, #f9a8d4 100%); }
+.grad-ocean { background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 50%, #8b5cf6 100%); }
+.grad-autumn { background: linear-gradient(135deg, #dc2626 0%, #ea580c 50%, #d97706 100%); }
+.grad-pastel { background: linear-gradient(135deg, #e9d5ff 0%, #fbcfe8 50%, #fef3c7 100%); }
+.grad-starry {
+  background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 25%, #3b82f6 50%, #8b5cf6 75%, #c084fc 100%);
+  position: relative;
+}
+.grad-starry::after {
+  content: '✦ ✧ ⋆ ✦ ⋆ ✧';
+  position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  color: rgba(255,255,255,0.4); font-size: 16px;
+  letter-spacing: 8px; white-space: nowrap;
+}
+
+/* ===== CORK BOARD ===== */
+.cork-bg {
+  background-color: #e8ddd0;
+  background-image:
+    radial-gradient(circle at 20% 20%, rgba(200,170,130,0.3) 0%, transparent 50%),
+    radial-gradient(circle at 70% 60%, rgba(180,150,110,0.2) 0%, transparent 50%),
+    url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='c'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.6' numOctaves='6' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0.1'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23c)' opacity='0.08'/%3E%3C/svg%3E");
+  border-radius: 24px;
+}
+
+/* ===== ANIMATIONS ===== */
+@keyframes gentleFloat {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+/* ============================================================
+   SCREEN 1: MY BOARDS
+   ============================================================ */
+.s1-header { text-align: center; margin-bottom: 8px; }
+.s1-brand {
+  font-size: 32px;
+  background: linear-gradient(135deg, #a855f7, #ec4899, #f97316);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  background-clip: text; letter-spacing: 2px;
+}
+.s1-greeting { font-size: 24px; font-weight: 700; }
+.s1-sub { font-size: 14px; color: #9b8b7a; margin-bottom: 24px; }
+
+.s1-boards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.board-card {
+  background: #fff;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(80,60,40,0.08), 0 1px 3px rgba(80,60,40,0.06);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
+}
+.board-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 8px 28px rgba(80,60,40,0.14);
+}
+.board-card-images {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 70px 70px;
+  gap: 3px; padding: 10px 10px 0;
+}
+.board-card-images .bci-main {
+  grid-row: 1 / 3; border-radius: 14px;
+  min-height: 143px;
+  display: flex; align-items: center; justify-content: center;
+}
+.board-card-images .bci-sm {
+  border-radius: 12px; min-height: 70px;
+  display: flex; align-items: center; justify-content: center;
+}
+.board-card-info { padding: 12px 14px 14px; }
+.board-card-title {
+  font-family: 'Zen Maru Gothic', serif;
+  font-weight: 700; font-size: 15px; line-height: 1.3; margin-bottom: 3px;
+}
+.board-card-count { font-size: 12px; color: #a89b8c; }
+
+.board-card-new {
+  background: transparent;
+  border: 2.5px dashed #cbbfb2;
+  box-shadow: none;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  min-height: 220px; gap: 10px;
+  transition: border-color 0.3s, background 0.3s;
+}
+.board-card-new:hover {
+  border-color: #a855f7; background: rgba(168,85,247,0.04);
+  box-shadow: none; transform: none;
+}
+.board-card-new .plus-icon {
+  width: 52px; height: 52px; border-radius: 50%;
+  background: linear-gradient(135deg, #f3e8ff, #fce7f3);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 26px; color: #a855f7;
+}
+.board-card-new .plus-label { font-size: 13px; color: #9b8b7a; font-weight: 500; }
+
+/* ============================================================
+   SCREEN 2: BOARD DETAIL
+   ============================================================ */
+.s2-container {
+  max-width: 960px; margin: 0 auto;
+}
+.s2-back {
+  font-size: 14px; color: #a855f7;
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-bottom: 12px;
+}
+.s2-title { font-size: 30px; line-height: 1.3; margin-bottom: 4px; }
+.s2-meta { font-size: 14px; color: #9b8b7a; margin-bottom: 20px; }
+
+.s2-collage-area {
+  padding: 24px;
+  position: relative;
+  min-height: 500px;
+}
+
+/* Desktop: place cards in a flex layout instead of absolute */
+.s2-cards-flex {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  align-items: flex-start;
+}
+.work-card {
+  border-radius: 18px;
+  overflow: visible;
+  box-shadow: 0 6px 24px rgba(80,60,40,0.13), 0 2px 6px rgba(80,60,40,0.08);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  cursor: pointer;
+  flex: 0 0 auto;
+  width: 240px;
+}
+.work-card:nth-child(1) { transform: rotate(-2deg); }
+.work-card:nth-child(2) { transform: rotate(1.5deg); margin-top: 30px; }
+.work-card:nth-child(3) { transform: rotate(-0.8deg); }
+.work-card:hover {
+  z-index: 10;
+  box-shadow: 0 12px 36px rgba(80,60,40,0.2);
+}
+.work-card-inner {
+  border-radius: 18px; overflow: hidden; background: #fff;
+}
+.work-card-img {
+  width: 100%; height: 160px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 42px; position: relative;
+}
+.work-card-body { padding: 14px 16px 16px; background: #fff; }
+.work-card-badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11px; font-weight: 700;
+  padding: 3px 10px; border-radius: 10px; margin-bottom: 6px;
+}
+.badge-book { background: #fef3c7; color: #92400e; }
+.badge-music { background: #ede9fe; color: #5b21b6; }
+.badge-movie { background: #dbeafe; color: #1e40af; }
+.work-card-name {
+  font-family: 'Zen Maru Gothic', serif;
+  font-weight: 700; font-size: 16px; line-height: 1.3; margin-bottom: 3px;
+}
+.work-card-author { font-size: 13px; color: #9b8b7a; }
+
+/* Card washi tape decoration */
+.card-washi {
+  position: absolute; z-index: 6;
+  height: 22px; border-radius: 2px; opacity: 0.5;
+}
+
+/* Pin decoration */
+.pin {
+  width: 16px; height: 16px; border-radius: 50%;
+  position: absolute; z-index: 6;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2), inset 0 1px 2px rgba(255,255,255,0.4);
+}
+.pin::after {
+  content: ''; position: absolute; top: 3px; left: 5px;
+  width: 5px; height: 5px; border-radius: 50%;
+  background: rgba(255,255,255,0.5);
+}
+.pin-red { background: radial-gradient(circle at 40% 35%, #f87171, #dc2626); }
+.pin-blue { background: radial-gradient(circle at 40% 35%, #60a5fa, #2563eb); }
+.pin-yellow { background: radial-gradient(circle at 40% 35%, #fbbf24, #d97706); }
+
+.s2-actions {
+  display: flex; gap: 12px;
+  justify-content: center;
+  padding: 24px 0 0;
+}
+.s2-btn {
+  padding: 14px 32px; border-radius: 16px; border: none;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-size: 15px; font-weight: 700; cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.s2-btn:hover { transform: translateY(-2px); }
+.s2-btn-like {
+  background: linear-gradient(135deg, #f3e8ff, #fce7f3);
+  color: #7c3aed;
+  box-shadow: 0 3px 12px rgba(168,85,247,0.15);
+}
+.s2-btn-save {
+  background: #fff; color: #6b5344;
+  box-shadow: 0 3px 12px rgba(80,60,40,0.08);
+  border: 1.5px solid #e8ddd0;
+}
+
+/* ============================================================
+   SCREEN 3: EXPLORE (Masonry)
+   ============================================================ */
+.s3-header { max-width: 700px; margin: 0 auto 20px; }
+.s3-title { font-size: 26px; margin-bottom: 16px; }
+.s3-search {
+  display: flex; align-items: center;
+  background: #fff; border-radius: 18px;
+  padding: 14px 20px; gap: 10px;
+  box-shadow: 0 2px 10px rgba(80,60,40,0.06);
+}
+.s3-search input {
+  border: none; outline: none;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-size: 15px; flex: 1; color: #3d3530; background: transparent;
+}
+.s3-search input::placeholder { color: #bbb0a2; }
+
+.s3-tags {
+  display: flex; gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+.s3-tag {
+  padding: 8px 18px; border-radius: 22px;
+  font-size: 13px; font-weight: 600;
+  white-space: nowrap; border: none; cursor: pointer;
+  transition: transform 0.2s;
+}
+.s3-tag:hover { transform: scale(1.05); }
+.s3-tag-hot { background: linear-gradient(135deg, #fecaca, #fed7aa); color: #9a3412; }
+.s3-tag-spring { background: linear-gradient(135deg, #fce7f3, #fbcfe8); color: #9d174d; }
+.s3-tag-novel { background: linear-gradient(135deg, #fef3c7, #fde68a); color: #92400e; }
+.s3-tag-music { background: linear-gradient(135deg, #ede9fe, #ddd6fe); color: #5b21b6; }
+.s3-tag-movie { background: linear-gradient(135deg, #dbeafe, #bfdbfe); color: #1e40af; }
+
+.s3-masonry {
+  column-count: 2; column-gap: 16px;
+  max-width: 960px; margin: 0 auto;
+}
+@media (min-width: 768px) { .s3-masonry { column-count: 3; } }
+@media (min-width: 1024px) { .s3-masonry { column-count: 4; } }
+
+.s3-masonry-card {
+  break-inside: avoid; margin-bottom: 16px;
+  background: #fff; border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 3px 14px rgba(80,60,40,0.07), 0 1px 3px rgba(80,60,40,0.05);
+  transition: transform 0.3s, box-shadow 0.3s;
+  cursor: pointer;
+}
+.s3-masonry-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(80,60,40,0.12);
+}
+.s3-mc-img {
+  width: 100%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 32px; position: relative;
+}
+.s3-mc-body { padding: 12px 14px 14px; }
+.s3-mc-title {
+  font-family: 'Zen Maru Gothic', serif;
+  font-weight: 700; font-size: 14px; line-height: 1.35; margin-bottom: 8px;
+}
+.s3-mc-user {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+}
+.s3-mc-avatar {
+  width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0;
+}
+.s3-mc-username { font-size: 12px; color: #9b8b7a; }
+.s3-mc-likes { font-size: 12px; color: #c4b5fd; }
+
+/* ============================================================
+   SCREEN 4: WORK DETAIL
+   ============================================================ */
+.s4-layout {
+  max-width: 960px; margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+@media (min-width: 768px) {
+  .s4-layout {
+    grid-template-columns: 360px 1fr;
+  }
+}
+.s4-hero {
+  height: 300px;
+  display: flex; align-items: center; justify-content: center;
+  position: relative; overflow: hidden;
+  border-radius: 24px;
+}
+.s4-hero-title {
+  color: #fff; font-size: 36px;
+  text-shadow: 0 2px 20px rgba(0,0,0,0.4);
+  z-index: 2; text-align: center; padding: 0 20px;
+}
+.s4-hero::before {
+  content: '✦'; position: absolute; top: 30px; right: 40px;
+  font-size: 20px; color: rgba(255,255,255,0.3);
+  animation: gentleFloat 3s ease-in-out infinite;
+}
+.s4-hero::after {
+  content: '⋆'; position: absolute; bottom: 40px; left: 30px;
+  font-size: 24px; color: rgba(255,255,255,0.25);
+  animation: gentleFloat 4s ease-in-out infinite 1s;
+}
+.s4-info { text-align: center; }
+@media (min-width: 768px) { .s4-info { text-align: left; padding-top: 20px; } }
+.s4-work-title { font-size: 28px; margin-bottom: 6px; }
+.s4-work-sub { font-size: 15px; color: #9b8b7a; margin-bottom: 4px; }
+.s4-work-meta { font-size: 13px; color: #bbb0a2; margin-bottom: 12px; }
+.s4-stars { font-size: 22px; letter-spacing: 2px; margin-bottom: 24px; color: #fbbf24; }
+
+.s4-section-title {
+  font-family: 'Zen Maru Gothic', serif;
+  font-weight: 700; font-size: 18px;
+  margin-bottom: 14px;
+}
+.s4-users-scroll {
+  display: flex; gap: 14px;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  padding-bottom: 16px;
+}
+.s4-users-scroll::-webkit-scrollbar { display: none; }
+.s4-user-card {
+  flex-shrink: 0; width: 150px;
+  background: #fff; border-radius: 20px;
+  padding: 18px 14px; text-align: center;
+  box-shadow: 0 3px 14px rgba(80,60,40,0.07);
+  transition: transform 0.3s;
+}
+.s4-user-card:hover { transform: translateY(-3px); }
+.s4-user-avatar {
+  width: 48px; height: 48px; border-radius: 50%;
+  margin: 0 auto 10px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 22px; color: #fff;
+}
+.s4-user-name { font-weight: 700; font-size: 14px; margin-bottom: 3px; }
+.s4-user-board { font-size: 12px; color: #9b8b7a; margin-bottom: 12px; line-height: 1.3; }
+.s4-follow-btn {
+  display: inline-block; padding: 6px 18px;
+  border-radius: 20px; border: 1.5px solid #c4b5fd;
+  color: #7c3aed; font-size: 12px; font-weight: 700;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  background: transparent; cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.s4-follow-btn:hover { background: #7c3aed; color: #fff; }
+
+.s4-related-scroll {
+  display: flex; gap: 14px;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  padding-bottom: 8px;
+}
+.s4-related-scroll::-webkit-scrollbar { display: none; }
+.s4-related-card {
+  flex-shrink: 0; width: 130px; cursor: pointer;
+  transition: transform 0.3s;
+}
+.s4-related-card:hover { transform: scale(1.05); }
+.s4-related-img {
+  width: 130px; height: 90px; border-radius: 16px; margin-bottom: 8px;
+  display: flex; align-items: center; justify-content: center; font-size: 24px;
+}
+.s4-related-name { font-size: 13px; font-weight: 500; line-height: 1.3; }
+.s4-related-type { font-size: 11px; color: #9b8b7a; }
+
+/* ============================================================
+   SCREEN 5: BOARD CREATION
+   ============================================================ */
+.s5-layout {
+  max-width: 800px; margin: 0 auto;
+}
+.s5-title { font-size: 26px; margin-bottom: 6px; }
+.s5-sub { font-size: 14px; color: #9b8b7a; margin-bottom: 28px; }
+
+.s5-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+}
+@media (min-width: 768px) {
+  .s5-form-grid { grid-template-columns: 1fr 1fr; }
+}
+
+.s5-field { margin-bottom: 0; }
+.s5-label {
+  font-size: 13px; font-weight: 700; color: #9b8b7a;
+  margin-bottom: 8px; display: block;
+}
+.s5-input {
+  width: 100%; padding: 14px 18px;
+  border-radius: 16px; border: 2px solid #e8ddd0;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-size: 15px; color: #3d3530; background: #fff;
+  outline: none; transition: border-color 0.3s, box-shadow 0.3s;
+}
+.s5-input:focus {
+  border-color: #c4b5fd;
+  box-shadow: 0 0 0 4px rgba(196,181,253,0.2);
+}
+.s5-input::placeholder { color: #cbbfb2; }
+
+.s5-styles-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+}
+.s5-style-opt {
+  text-align: center; cursor: pointer; transition: transform 0.2s;
+}
+.s5-style-opt:hover { transform: scale(1.05); }
+.s5-style-opt.selected .s5-style-preview {
+  outline: 3px solid #a855f7; outline-offset: 3px;
+}
+.s5-style-preview {
+  width: 100%; height: 64px; border-radius: 14px; margin-bottom: 6px;
+}
+.s5-style-name { font-size: 12px; font-weight: 500; color: #6b5344; }
+
+.s5-add-section { margin-top: 24px; }
+.s5-add-label { font-size: 15px; font-weight: 700; margin-bottom: 12px; }
+.s5-add-search {
+  display: flex; align-items: center;
+  background: #fff; border-radius: 16px;
+  padding: 12px 16px; gap: 10px;
+  box-shadow: 0 2px 10px rgba(80,60,40,0.06);
+  margin-bottom: 16px;
+}
+.s5-add-search input {
+  border: none; outline: none;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-size: 14px; flex: 1; background: transparent; color: #3d3530;
+}
+.s5-add-search input::placeholder { color: #bbb0a2; }
+.s5-slots {
+  display: flex; gap: 12px;
+}
+.s5-slot {
+  flex: 1; height: 120px; border-radius: 18px;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  position: relative; transition: transform 0.2s;
+}
+.s5-slot:hover { transform: scale(1.03); }
+.s5-slot-empty {
+  border: 2px dashed #cbbfb2;
+  background: rgba(255,255,255,0.5); cursor: pointer;
+}
+.s5-slot-empty:hover { border-color: #a855f7; }
+.s5-slot-empty .plus { font-size: 26px; color: #cbbfb2; }
+.s5-slot-filled {
+  overflow: hidden;
+  box-shadow: 0 3px 10px rgba(80,60,40,0.1);
+}
+.s5-slot-filled .slot-overlay {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  padding: 8px 10px;
+  background: linear-gradient(transparent, rgba(0,0,0,0.5));
+  color: #fff; font-size: 11px; font-weight: 500;
+  border-radius: 0 0 18px 18px;
+}
+.s5-slot-drag {
+  position: absolute; top: 8px; right: 8px;
+  width: 22px; height: 22px; border-radius: 7px;
+  background: rgba(255,255,255,0.8);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; color: #9b8b7a;
+}
+
+.s5-preview-card {
+  background: #fff; border-radius: 22px;
+  padding: 18px; box-shadow: 0 3px 14px rgba(80,60,40,0.07);
+  margin-top: 24px;
+}
+.s5-preview-name {
+  font-family: 'Zen Maru Gothic', serif;
+  font-weight: 700; font-size: 17px;
+  margin-bottom: 10px; text-align: center;
+}
+.s5-preview-items {
+  display: flex; gap: 8px; justify-content: center;
+}
+.s5-preview-item {
+  width: 72px; height: 54px; border-radius: 12px;
+}
+.s5-preview-meta {
+  text-align: center; font-size: 12px; color: #9b8b7a; margin-top: 10px;
+}
+
+.s5-create-btn {
+  display: block; width: 100%; max-width: 400px;
+  margin: 32px auto 0; padding: 18px;
+  border: none; border-radius: 20px;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-size: 17px; font-weight: 700; color: #fff;
+  background: linear-gradient(135deg, #a855f7, #ec4899);
+  cursor: pointer;
+  box-shadow: 0 6px 24px rgba(168,85,247,0.3);
+  transition: transform 0.2s, box-shadow 0.2s;
+  letter-spacing: 0.5px;
+}
+.s5-create-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 32px rgba(168,85,247,0.4);
+}
+
+/* ===== BOTTOM NAV (fixed, mobile) ===== */
+.bottom-nav {
+  position: fixed; bottom: 0; left: 0; right: 0; z-index: 50;
+  display: flex; justify-content: space-around; align-items: center;
+  padding: 10px 0 max(16px, env(safe-area-inset-bottom));
+  background: rgba(255,255,253,0.95);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(200,190,175,0.3);
+}
+@media (min-width: 768px) {
+  .bottom-nav { display: none; }
+}
+.nav-item {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 2px; font-size: 10px; color: #9b8b7a;
+  transition: color 0.2s;
+}
+.nav-item.active { color: #a855f7; }
+.nav-item .nav-icon { font-size: 22px; }
+
+/* Mobile padding for fixed nav */
+@media (max-width: 767px) {
+  .screen-section:last-child { padding-bottom: 120px; }
+}
+</style>
+</head>
+<body>
+
+<!-- Screen Navigation (demo) -->
+<nav class="screen-nav">
+  <a href="#screen-1" class="active">📌 My Boards</a>
+  <a href="#screen-2">🎨 Board Detail</a>
+  <a href="#screen-3">🔍 Explore</a>
+  <a href="#screen-4">📄 Work Detail</a>
+  <a href="#screen-5">✨ Board Creation</a>
+</nav>
+
+<div class="app-shell">
+
+<!-- ========== SCREEN 1: MY BOARDS ========== -->
+<section id="screen-1" class="screen-section">
+  <span class="screen-label">📱 Screen 1: My Boards (Home / Profile)</span>
+
+  <div class="s1-header">
+    <div class="heading-brand s1-brand">すきコレ</div>
+  </div>
+  <div class="heading-display s1-greeting" style="text-align:center;">みくりのコレクション 🎨</div>
+  <div class="s1-sub" style="text-align:center;">4つのボード • 12作品を保存中</div>
+
+  <div class="s1-boards">
+    <div class="board-card">
+      <div class="board-card-images">
+        <div class="bci-main grad-warm" style="font-size:24px;">📚</div>
+        <div class="bci-sm grad-cool" style="font-size:18px;">🎵</div>
+        <div class="bci-sm grad-starry" style="font-size:18px;">🎬</div>
+      </div>
+      <div class="board-card-info">
+        <div class="board-card-title">推しの作品 💜</div>
+        <div class="board-card-count">3作品</div>
+      </div>
+    </div>
+    <div class="board-card">
+      <div class="board-card-images">
+        <div class="bci-main grad-night" style="font-size:24px;">🌙</div>
+        <div class="bci-sm grad-ocean" style="font-size:18px;">🎵</div>
+        <div class="bci-sm grad-sakura" style="font-size:18px;">📖</div>
+      </div>
+      <div class="board-card-info">
+        <div class="board-card-title">泣きたい夜に 🌙</div>
+        <div class="board-card-count">3作品</div>
+      </div>
+    </div>
+    <div class="board-card">
+      <div class="board-card-images">
+        <div class="bci-main grad-sunset" style="font-size:24px;">🌻</div>
+        <div class="bci-sm grad-forest" style="font-size:18px;">🎵</div>
+        <div class="bci-sm grad-pastel" style="font-size:18px;">🎶</div>
+      </div>
+      <div class="board-card-info">
+        <div class="board-card-title">夏に聴きたい 🌻</div>
+        <div class="board-card-count">3作品</div>
+      </div>
+    </div>
+    <div class="board-card board-card-new">
+      <div class="plus-icon">+</div>
+      <div class="plus-label">新しいボード</div>
+    </div>
+  </div>
+</section>
+
+<!-- ========== SCREEN 2: BOARD DETAIL ========== -->
+<section id="screen-2" class="screen-section">
+  <span class="screen-label">📱 Screen 2: Board Detail</span>
+
+  <div class="s2-container">
+    <a class="s2-back" href="#screen-1">← ボード一覧</a>
+    <div class="heading-display s2-title">推しの作品 💜</div>
+    <div class="s2-meta">by みくり • 3作品 • 24💜</div>
+
+    <div class="s2-collage-area cork-bg">
+      <!-- Decorative pins -->
+      <div class="pin pin-red" style="position:absolute;top:16px;left:48%;"></div>
+      <div class="pin pin-blue" style="position:absolute;top:40px;right:60px;"></div>
+      <div class="pin pin-yellow" style="position:absolute;bottom:40px;left:80px;"></div>
+
+      <div class="s2-cards-flex">
+        <!-- Card 1 -->
+        <div class="work-card" style="position:relative;">
+          <div class="card-washi" style="width:64px;top:-10px;left:30%;background:linear-gradient(90deg,#fbcfe8,#fce7f3);transform:rotate(2deg);"></div>
+          <div class="work-card-inner">
+            <div class="work-card-img grad-warm">📚</div>
+            <div class="work-card-body">
+              <div class="work-card-badge badge-book">📖 マンガ</div>
+              <div class="work-card-name">ハチミツとクローバー</div>
+              <div class="work-card-author">羽海野チカ</div>
+            </div>
+          </div>
+        </div>
+        <!-- Card 2 -->
+        <div class="work-card" style="position:relative;">
+          <div class="card-washi" style="width:58px;top:-10px;right:24px;background:linear-gradient(90deg,#ddd6fe,#ede9fe);transform:rotate(-3deg);"></div>
+          <div class="work-card-inner">
+            <div class="work-card-img grad-cool">🎵</div>
+            <div class="work-card-body">
+              <div class="work-card-badge badge-music">🎵 音楽</div>
+              <div class="work-card-name">夜に駆ける</div>
+              <div class="work-card-author">YOASOBI</div>
+            </div>
+          </div>
+        </div>
+        <!-- Card 3 -->
+        <div class="work-card" style="position:relative;">
+          <div class="card-washi" style="width:72px;top:-10px;left:25%;background:linear-gradient(90deg,#bfdbfe,#dbeafe);transform:rotate(1deg);"></div>
+          <div class="work-card-inner">
+            <div class="work-card-img grad-starry" style="color:#fff;">🎬</div>
+            <div class="work-card-body">
+              <div class="work-card-badge badge-movie">🎬 映画</div>
+              <div class="work-card-name">君の名は。</div>
+              <div class="work-card-author">新海誠 監督</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="s2-actions">
+      <button class="s2-btn s2-btn-like">💜 いいね 24</button>
+      <button class="s2-btn s2-btn-save">📌 保存</button>
+    </div>
+  </div>
+</section>
+
+<!-- ========== SCREEN 3: EXPLORE ========== -->
+<section id="screen-3" class="screen-section">
+  <span class="screen-label">📱 Screen 3: Explore (Pinterest-style Masonry)</span>
+
+  <div class="s3-header">
+    <div class="heading-display s3-title" style="text-align:center;">さがす 🔍</div>
+    <div class="s3-search">
+      <span>🔍</span>
+      <input type="text" placeholder="ボードやテーマを探す...">
+    </div>
+  </div>
+
+  <div class="s3-tags">
+    <button class="s3-tag s3-tag-hot">🔥 推し</button>
+    <button class="s3-tag s3-tag-spring">🌸 春アニメ</button>
+    <button class="s3-tag s3-tag-novel">📖 小説</button>
+    <button class="s3-tag s3-tag-music">🎵 邦楽</button>
+    <button class="s3-tag s3-tag-movie">🎬 泣ける映画</button>
+  </div>
+
+  <div class="s3-masonry">
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-cool" style="height:180px;">💜</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">推しの作品TOP3</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-sakura"></div>
+          <span class="s3-mc-username">あやか</span>
+        </div>
+        <div class="s3-mc-likes">💜 42</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-sunset" style="height:120px;">🌅</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">エモい曲だけ</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-warm"></div>
+          <span class="s3-mc-username">ゆうた</span>
+        </div>
+        <div class="s3-mc-likes">💜 18</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-night" style="height:150px;">🌙</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">泣ける映画TOP3</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-ocean"></div>
+          <span class="s3-mc-username">みく</span>
+        </div>
+        <div class="s3-mc-likes">💜 56</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-forest" style="height:170px;">🌿</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">癒しの作品たち</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-forest"></div>
+          <span class="s3-mc-username">はな</span>
+        </div>
+        <div class="s3-mc-likes">💜 31</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-sakura" style="height:110px;">🌸</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">春に読みたい本</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-pastel"></div>
+          <span class="s3-mc-username">りこ</span>
+        </div>
+        <div class="s3-mc-likes">💜 27</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-autumn" style="height:140px;">🔥</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">熱いバトルもの</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-sunset"></div>
+          <span class="s3-mc-username">れん</span>
+        </div>
+        <div class="s3-mc-likes">💜 39</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-pastel" style="height:160px;">✨</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">人生変わった3作品</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-cool"></div>
+          <span class="s3-mc-username">そら</span>
+        </div>
+        <div class="s3-mc-likes">💜 63</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-ocean" style="height:120px;">🎧</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">深夜のプレイリスト</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-night"></div>
+          <span class="s3-mc-username">ひなた</span>
+        </div>
+        <div class="s3-mc-likes">💜 21</div>
+      </div>
+    </div>
+    <!-- Extra cards for wider layouts -->
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-warm" style="height:130px;">📖</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">何度も読み返す本</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-warm"></div>
+          <span class="s3-mc-username">まお</span>
+        </div>
+        <div class="s3-mc-likes">💜 35</div>
+      </div>
+    </div>
+    <div class="s3-masonry-card">
+      <div class="s3-mc-img grad-sky" style="height:155px;">☁️</div>
+      <div class="s3-mc-body">
+        <div class="s3-mc-title">休日まったりセット</div>
+        <div class="s3-mc-user">
+          <div class="s3-mc-avatar grad-sky"></div>
+          <span class="s3-mc-username">けい</span>
+        </div>
+        <div class="s3-mc-likes">💜 48</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ========== SCREEN 4: WORK DETAIL ========== -->
+<section id="screen-4" class="screen-section">
+  <span class="screen-label">📱 Screen 4: Work Detail / Connection</span>
+
+  <div class="s4-layout">
+    <div>
+      <div class="s4-hero grad-starry">
+        <div class="heading-display s4-hero-title">君の名は。</div>
+      </div>
+    </div>
+    <div class="s4-info">
+      <div class="heading-display s4-work-title">君の名は。</div>
+      <div class="s4-work-sub">新海誠 監督</div>
+      <div class="s4-work-meta">🎬 映画 • 2016</div>
+      <div class="s4-stars">⭐⭐⭐⭐⭐</div>
+    </div>
+  </div>
+
+  <div style="max-width:960px;margin:32px auto 0;">
+    <div class="s4-section-title">この作品を選んだ人 👥</div>
+    <div class="s4-users-scroll">
+      <div class="s4-user-card">
+        <div class="s4-user-avatar grad-sakura">🎨</div>
+        <div class="s4-user-name">みくり</div>
+        <div class="s4-user-board">推しの作品</div>
+        <button class="s4-follow-btn">フォロー</button>
+      </div>
+      <div class="s4-user-card">
+        <div class="s4-user-avatar grad-cool">🌙</div>
+        <div class="s4-user-name">あやか</div>
+        <div class="s4-user-board">泣ける映画TOP3</div>
+        <button class="s4-follow-btn">フォロー</button>
+      </div>
+      <div class="s4-user-card">
+        <div class="s4-user-avatar grad-sunset">🎬</div>
+        <div class="s4-user-name">ゆい</div>
+        <div class="s4-user-board">何度も観る映画</div>
+        <button class="s4-follow-btn">フォロー</button>
+      </div>
+      <div class="s4-user-card">
+        <div class="s4-user-avatar grad-forest">📖</div>
+        <div class="s4-user-name">れん</div>
+        <div class="s4-user-board">人生変わった作品</div>
+        <button class="s4-follow-btn">フォロー</button>
+      </div>
+      <div class="s4-user-card">
+        <div class="s4-user-avatar grad-ocean">🎵</div>
+        <div class="s4-user-name">ひろ</div>
+        <div class="s4-user-board">音楽好きの3選</div>
+        <button class="s4-follow-btn">フォロー</button>
+      </div>
+    </div>
+
+    <div class="s4-section-title" style="margin-top:24px;">関連する作品 ✨</div>
+    <div class="s4-related-scroll">
+      <div class="s4-related-card">
+        <div class="s4-related-img grad-sky">🎬</div>
+        <div class="s4-related-name">天気の子</div>
+        <div class="s4-related-type">映画 • 2019</div>
+      </div>
+      <div class="s4-related-card">
+        <div class="s4-related-img grad-cool">🎬</div>
+        <div class="s4-related-name">すずめの戸締まり</div>
+        <div class="s4-related-type">映画 • 2022</div>
+      </div>
+      <div class="s4-related-card">
+        <div class="s4-related-img grad-sakura">🎬</div>
+        <div class="s4-related-name">秒速5センチメートル</div>
+        <div class="s4-related-type">映画 • 2007</div>
+      </div>
+      <div class="s4-related-card">
+        <div class="s4-related-img grad-pastel">🎬</div>
+        <div class="s4-related-name">言の葉の庭</div>
+        <div class="s4-related-type">映画 • 2013</div>
+      </div>
+      <div class="s4-related-card">
+        <div class="s4-related-img grad-night">🎬</div>
+        <div class="s4-related-name">星を追う子ども</div>
+        <div class="s4-related-type">映画 • 2011</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ========== SCREEN 5: BOARD CREATION ========== -->
+<section id="screen-5" class="screen-section">
+  <span class="screen-label">📱 Screen 5: Board Creation</span>
+
+  <div class="s5-layout">
+    <div class="heading-display s5-title">新しいボードをつくる 📌</div>
+    <div class="s5-sub">好きな作品をあつめて、あなただけのコレクションを作ろう</div>
+
+    <div class="s5-form-grid">
+      <div>
+        <div class="s5-field">
+          <label class="s5-label">ボードの名前</label>
+          <input class="s5-input" type="text" placeholder="ボードの名前..." value="夏の思い出 🌻">
+        </div>
+
+        <div style="margin-top:24px;">
+          <label class="s5-label">カバースタイル</label>
+          <div class="s5-styles-grid">
+            <div class="s5-style-opt selected">
+              <div class="s5-style-preview" style="background:linear-gradient(135deg,#fef3c7,#fed7aa,#fde68a);"></div>
+              <div class="s5-style-name">ナチュラル</div>
+            </div>
+            <div class="s5-style-opt">
+              <div class="s5-style-preview" style="background:linear-gradient(135deg,#fda4af,#fb923c,#a78bfa);"></div>
+              <div class="s5-style-name">ポップ</div>
+            </div>
+            <div class="s5-style-opt">
+              <div class="s5-style-preview" style="background:linear-gradient(135deg,#1e1b4b,#312e81,#4f46e5);"></div>
+              <div class="s5-style-name">ダーク</div>
+            </div>
+            <div class="s5-style-opt">
+              <div class="s5-style-preview" style="background:linear-gradient(135deg,#e9d5ff,#fbcfe8,#fef3c7);"></div>
+              <div class="s5-style-name">パステル</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="s5-add-section" style="margin-top:0;">
+          <div class="s5-add-label">作品を追加 🔍</div>
+          <div class="s5-add-search">
+            <span>🔍</span>
+            <input type="text" placeholder="作品名やアーティストを検索...">
+          </div>
+          <div class="s5-slots">
+            <div class="s5-slot s5-slot-filled grad-warm" style="position:relative;">
+              <span style="font-size:32px;">📚</span>
+              <div class="slot-overlay">ハチミツと<br>クローバー</div>
+              <div class="s5-slot-drag">⋮⋮</div>
+            </div>
+            <div class="s5-slot s5-slot-empty">
+              <div class="plus">+</div>
+            </div>
+            <div class="s5-slot s5-slot-empty">
+              <div class="plus">+</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="s5-preview-card">
+          <div class="s5-preview-name">夏の思い出 🌻</div>
+          <div class="s5-preview-items">
+            <div class="s5-preview-item grad-warm" style="display:flex;align-items:center;justify-content:center;font-size:18px;">📚</div>
+            <div class="s5-preview-item" style="border:1.5px dashed #cbbfb2;"></div>
+            <div class="s5-preview-item" style="border:1.5px dashed #cbbfb2;"></div>
+          </div>
+          <div class="s5-preview-meta">1/3 作品を追加済み</div>
+        </div>
+      </div>
+    </div>
+
+    <button class="s5-create-btn">ボードを作成 ✨</button>
+  </div>
+</section>
+
+</div><!-- /app-shell -->
+
+<!-- Bottom Nav (mobile) -->
+<div class="bottom-nav">
+  <a class="nav-item active" href="#screen-1"><span class="nav-icon">📌</span><span>マイボード</span></a>
+  <a class="nav-item" href="#screen-3"><span class="nav-icon">🔍</span><span>さがす</span></a>
+  <a class="nav-item" href="#screen-5"><span class="nav-icon">✨</span><span>つくる</span></a>
+  <a class="nav-item" href="#"><span class="nav-icon">💬</span><span>つながり</span></a>
+</div>
+
+<script>
+// Highlight active nav link on scroll
+const navLinks = document.querySelectorAll('.screen-nav a');
+const sections = document.querySelectorAll('.screen-section');
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const id = entry.target.id;
+      navLinks.forEach(l => l.classList.toggle('active', l.getAttribute('href') === '#' + id));
+    }
+  });
+}, { threshold: 0.3 });
+sections.forEach(s => observer.observe(s));
+</script>
+</body>
+</html>

--- a/src/components/GalleryCard.test.tsx
+++ b/src/components/GalleryCard.test.tsx
@@ -47,10 +47,11 @@ describe('GalleryCard', () => {
     expect(link).toHaveAttribute('href', '/s/abc123')
   })
 
-  it('renders 3 thumbnail images', () => {
+  it('renders thumbnail images (hero + small)', () => {
     renderCard()
     const images = screen.getAllByRole('img')
-    expect(images).toHaveLength(3)
+    // 3 hero images + 3 small thumbnails = 6
+    expect(images).toHaveLength(6)
   })
 
   it('renders fallback when theme is empty', () => {
@@ -66,13 +67,15 @@ describe('GalleryCard', () => {
       movieThumb: '',
     })
     expect(screen.queryAllByRole('img')).toHaveLength(0)
-    expect(screen.getByText('タップして見る')).toBeInTheDocument()
+    // Pin emoji is shown as fallback
+    expect(screen.getByText('📌')).toBeInTheDocument()
   })
 
   it('skips thumbnail for empty URL', () => {
     renderCard({ ...defaultProps, bookThumb: '' })
     const images = screen.getAllByRole('img')
-    expect(images).toHaveLength(2)
+    // 2 hero + 2 small = 4
+    expect(images).toHaveLength(4)
   })
 
   it('renders reaction count', () => {

--- a/src/components/GalleryCard.tsx
+++ b/src/components/GalleryCard.tsx
@@ -4,6 +4,35 @@ import { useReaction } from '../hooks/useReaction'
 const PLACEHOLDER =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" fill="%23e8e0d8"><rect width="80" height="80"/></svg>'
 
+/** Deterministic gradient class based on string hash */
+const GRADIENTS = [
+  'grad-warm',
+  'grad-cool',
+  'grad-sky',
+  'grad-sunset',
+  'grad-forest',
+  'grad-night',
+  'grad-sakura',
+  'grad-ocean',
+  'grad-autumn',
+  'grad-pastel',
+  'grad-starry',
+] as const
+
+function hashToGradient(s: string): string {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return GRADIENTS[Math.abs(h) % GRADIENTS.length]
+}
+
+/** Varying image heights for masonry look */
+const HEIGHT_CLASSES = ['h-28', 'h-32', 'h-36', 'h-40'] as const
+function hashToHeight(s: string): string {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 37 + s.charCodeAt(i)) | 0
+  return HEIGHT_CLASSES[Math.abs(h) % HEIGHT_CLASSES.length]
+}
+
 type Props = {
   id: string
   theme: string
@@ -20,7 +49,7 @@ function Thumbnail({ src, alt }: { src: string; alt: string }) {
     <img
       src={src}
       alt={alt}
-      className="h-18 w-18 rounded-md object-cover shadow-sm"
+      className="h-12 w-12 rounded-lg object-cover shadow-sm"
       loading="lazy"
       onError={(e) => {
         const img = e.target as HTMLImageElement
@@ -30,21 +59,12 @@ function Thumbnail({ src, alt }: { src: string; alt: string }) {
   )
 }
 
-function formatDate(unixSeconds: number): string {
-  return new Date(unixSeconds * 1000).toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
 export default function GalleryCard({
   id,
   theme,
   bookThumb,
   musicThumb,
   movieThumb,
-  createdAt,
   reactionCount: initialReactionCount,
 }: Props) {
   const hasThumbs = bookThumb || musicThumb || movieThumb
@@ -52,6 +72,8 @@ export default function GalleryCard({
     id,
     initialReactionCount,
   )
+  const gradClass = hashToGradient(id)
+  const heightClass = hashToHeight(id)
 
   const handleReaction = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -62,81 +84,99 @@ export default function GalleryCard({
   return (
     <Link
       to={`/s/${id}`}
-      className="group block transition-all duration-200 hover:-translate-y-1"
-      style={{
-        borderRadius: 'var(--radius-card)',
-        border: '1.5px solid var(--color-border)',
-        boxShadow: '0 2px 12px rgba(62, 42, 20, 0.06)',
-      }}
+      className="masonry-item block overflow-hidden rounded-2xl bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
     >
+      {/* Hero image area */}
       <div
-        className="flex flex-col p-4"
-        style={{
-          borderRadius: 'var(--radius-card-inner)',
-          background: 'var(--color-surface)',
-        }}
+        className={`${gradClass} ${heightClass} relative flex items-center justify-content-center`}
       >
-        {/* Theme */}
+        {hasThumbs ? (
+          <div className="flex w-full items-end justify-center gap-1.5 p-3">
+            {bookThumb && (
+              <img
+                src={bookThumb}
+                alt="Book"
+                className="h-16 w-12 rounded-md object-cover shadow-md"
+                loading="lazy"
+                onError={(e) => {
+                  const img = e.target as HTMLImageElement
+                  if (img.src !== PLACEHOLDER) img.src = PLACEHOLDER
+                }}
+              />
+            )}
+            {musicThumb && (
+              <img
+                src={musicThumb}
+                alt="Music"
+                className="h-16 w-12 rounded-md object-cover shadow-md"
+                loading="lazy"
+                onError={(e) => {
+                  const img = e.target as HTMLImageElement
+                  if (img.src !== PLACEHOLDER) img.src = PLACEHOLDER
+                }}
+              />
+            )}
+            {movieThumb && (
+              <img
+                src={movieThumb}
+                alt="Movie"
+                className="h-16 w-12 rounded-md object-cover shadow-md"
+                loading="lazy"
+                onError={(e) => {
+                  const img = e.target as HTMLImageElement
+                  if (img.src !== PLACEHOLDER) img.src = PLACEHOLDER
+                }}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="flex w-full items-center justify-center">
+            <span className="text-3xl opacity-60">📌</span>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="px-3 pb-3 pt-2.5">
         <h3
-          className="mb-3 truncate text-sm font-bold"
+          className="mb-2 line-clamp-2 text-sm font-bold leading-snug"
           style={{
-            color: 'var(--color-text-primary)',
             fontFamily: 'var(--font-display)',
+            color: 'var(--color-text-primary)',
           }}
         >
           {theme || 'No Theme'}
         </h3>
 
-        {/* Thumbnails */}
-        {hasThumbs ? (
-          <div className="flex gap-2">
+        {/* Thumbnails row (small) */}
+        {hasThumbs && (
+          <div className="mb-2 flex gap-1.5">
             <Thumbnail src={bookThumb} alt="Book" />
             <Thumbnail src={musicThumb} alt="Music" />
             <Thumbnail src={movieThumb} alt="Movie" />
           </div>
-        ) : (
-          <div
-            className="flex h-18 items-center justify-center rounded-md"
-            style={{ backgroundColor: 'var(--color-bg)' }}
-          >
-            <span
-              className="text-xs"
-              style={{ color: 'var(--color-text-secondary)' }}
-            >
-              タップして見る
-            </span>
-          </div>
         )}
 
-        {/* Footer: Date + Reaction */}
-        <div className="mt-3 flex items-center justify-between">
-          <p
-            className="text-xs"
-            style={{ color: 'var(--color-text-secondary)' }}
+        {/* Reaction */}
+        <button
+          type="button"
+          onClick={handleReaction}
+          aria-label="いいね"
+          className="flex items-center gap-1 text-xs transition-colors duration-150"
+          style={{
+            color: reacted
+              ? 'var(--color-primary)'
+              : 'var(--color-text-secondary)',
+          }}
+        >
+          <span
+            className="transition-transform duration-150"
+            style={{ transform: reacted ? 'scale(1.2)' : 'scale(1)' }}
           >
-            {formatDate(createdAt)}
-          </p>
-
-          <button
-            type="button"
-            onClick={handleReaction}
-            aria-label="いいね"
-            className="flex items-center gap-1 rounded-full px-2 py-0.5 text-xs transition-colors duration-150"
-            style={{
-              color: reacted
-                ? 'var(--color-primary)'
-                : 'var(--color-text-secondary)',
-            }}
-          >
-            <span
-              className="transition-transform duration-150"
-              style={{ transform: reacted ? 'scale(1.2)' : 'scale(1)' }}
-            >
-              {reacted ? '❤️' : '🩵'}
-            </span>
-            <span>{count}</span>
-          </button>
-        </div>
+            {reacted ? '❤️' : '💜'}
+          </span>
+          <span>{count}</span>
+        </button>
       </div>
     </Link>
   )

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -11,7 +11,6 @@ import { useWorkFetch } from '../hooks/useWorkFetch'
 import { usePreGeneratedImage } from '../hooks/usePreGeneratedImage'
 import { useMergedRef } from '../hooks/useMergedRef'
 import DataCredits from './DataCredits'
-import PageHeader from './PageHeader'
 
 type Top3Params = {
   theme: string
@@ -23,6 +22,30 @@ type Top3Params = {
 type Props = {
   params: Top3Params
   existingShareId?: string
+}
+
+/** Decorative washi tape above a work card */
+function WashiTape({
+  color,
+  rotate,
+  left,
+}: {
+  color: string
+  rotate: string
+  left: string
+}) {
+  return (
+    <div
+      className="washi-tape"
+      style={{
+        width: 60,
+        background: color,
+        transform: `rotate(${rotate})`,
+        top: -10,
+        left,
+      }}
+    />
+  )
 }
 
 export default function Top3Content({ params, existingShareId }: Props) {
@@ -67,55 +90,115 @@ export default function Top3Content({ params, existingShareId }: Props) {
   }
 
   return (
-    <div
-      className="min-h-screen"
-      style={{
-        background:
-          'linear-gradient(180deg, var(--color-bg) 0%, #f5f0eb 50%, #efe8e0 100%)',
-      }}
-    >
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <div className="mx-auto max-w-4xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
-        <PageHeader title="すきコレ" />
+        {/* Header */}
+        <div className="mb-2 text-center">
+          <Link
+            to="/gallery"
+            className="mb-3 inline-flex items-center gap-1 text-sm font-medium transition-colors"
+            style={{ color: 'var(--color-primary)' }}
+          >
+            ← みんなのボード
+          </Link>
+          <h1
+            className="brand-gradient-text text-3xl font-extrabold tracking-tight sm:text-4xl"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            すきコレ
+          </h1>
+        </div>
 
-        {/* Theme display with decorative quotes via CSS pseudo-elements */}
+        {/* Theme title */}
         {params.theme && (
-          <div className="mt-3 text-center">
+          <div className="mt-2 text-center">
             <h2
-              className="theme-quote text-xl font-medium"
-              style={{ color: 'var(--color-text-primary)' }}
+              className="text-xl font-bold sm:text-2xl"
+              style={{
+                fontFamily: 'var(--font-display)',
+                color: 'var(--color-text-primary)',
+              }}
             >
               {params.theme}
             </h2>
           </div>
         )}
 
-        <div className="mt-4 flex flex-col items-stretch gap-4 sm:mt-6 sm:flex-row">
-          <div className="animate-fade-in-up flex-1">
-            <WorkCard
-              work={book.data}
-              loading={book.loading}
-              error={book.error}
-              label="📚 本"
-              onRetry={book.error ? book.retry : undefined}
-            />
-          </div>
-          <div className="animate-fade-in-up animate-delay-100 flex-1">
-            <WorkCard
-              work={music.data}
-              loading={music.loading}
-              error={music.error}
-              label="🎵 音楽"
-              onRetry={music.error ? music.retry : undefined}
-            />
-          </div>
-          <div className="animate-fade-in-up animate-delay-200 flex-1">
-            <WorkCard
-              work={movie.data}
-              loading={movie.loading}
-              error={movie.error}
-              label="🎬 映画"
-              onRetry={movie.error ? movie.retry : undefined}
-            />
+        {/* Cork board area */}
+        <div className="cork-bg relative mt-6 rounded-3xl p-5 sm:p-8">
+          {/* Decorative pushpins */}
+          <div
+            className="pushpin pushpin-red"
+            style={{ top: 12, left: '48%' }}
+            aria-hidden="true"
+          />
+          <div
+            className="pushpin pushpin-blue"
+            style={{ top: 20, right: 40 }}
+            aria-hidden="true"
+          />
+          <div
+            className="pushpin pushpin-yellow"
+            style={{ bottom: 20, left: 60 }}
+            aria-hidden="true"
+          />
+
+          {/* Work cards with slight rotation */}
+          <div className="flex flex-col items-stretch gap-5 sm:flex-row sm:justify-center sm:gap-6">
+            <div
+              className="animate-fade-in-up relative flex-1"
+              style={{ transform: 'rotate(-1.5deg)' }}
+            >
+              <WashiTape
+                color="linear-gradient(90deg, #fbcfe8, #fce7f3)"
+                rotate="2deg"
+                left="30%"
+              />
+              <WorkCard
+                work={book.data}
+                loading={book.loading}
+                error={book.error}
+                label="📚 本"
+                onRetry={book.error ? book.retry : undefined}
+              />
+            </div>
+            <div
+              className="animate-fade-in-up animate-delay-100 relative flex-1"
+              style={{
+                transform: 'rotate(1deg)',
+                marginTop: 'var(--card-offset, 0px)',
+              }}
+            >
+              <WashiTape
+                color="linear-gradient(90deg, #ddd6fe, #ede9fe)"
+                rotate="-3deg"
+                left="25%"
+              />
+              <WorkCard
+                work={music.data}
+                loading={music.loading}
+                error={music.error}
+                label="🎵 音楽"
+                onRetry={music.error ? music.retry : undefined}
+              />
+            </div>
+            <div
+              className="animate-fade-in-up animate-delay-200 relative flex-1"
+              style={{ transform: 'rotate(-0.5deg)' }}
+            >
+              <WashiTape
+                color="linear-gradient(90deg, #bfdbfe, #dbeafe)"
+                rotate="1deg"
+                left="35%"
+              />
+              <WorkCard
+                work={movie.data}
+                loading={movie.loading}
+                error={movie.error}
+                label="🎬 映画"
+                onRetry={movie.error ? movie.retry : undefined}
+              />
+            </div>
           </div>
         </div>
 
@@ -149,7 +232,7 @@ export default function Top3Content({ params, existingShareId }: Props) {
         <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
           <PillLinkButton to={buildEditUrl(params)}>← 戻る</PillLinkButton>
           <PillLinkButton to="/gallery" color="secondary">
-            🎨 みんなの推し
+            🔍 みんなのボード
           </PillLinkButton>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -240,3 +240,202 @@ body {
   font-family: Georgia, serif;
   line-height: 1;
 }
+
+/* ========================================
+   Collection Board UI - Shared Styles
+   ======================================== */
+
+/* Cork board texture background */
+.cork-bg {
+  background-color: #e8ddd0;
+  background-image:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(200, 170, 130, 0.3) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 70% 60%,
+      rgba(180, 150, 110, 0.2) 0%,
+      transparent 50%
+    ),
+    url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='c'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.6' numOctaves='6' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0.1'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23c)' opacity='0.08'/%3E%3C/svg%3E");
+}
+
+/* Gradient presets for board card images */
+.grad-warm {
+  background: linear-gradient(135deg, #fde68a 0%, #fed7aa 50%, #fecaca 100%);
+}
+.grad-cool {
+  background: linear-gradient(135deg, #c4b5fd 0%, #818cf8 50%, #6366f1 100%);
+}
+.grad-sky {
+  background: linear-gradient(135deg, #7dd3fc 0%, #93c5fd 50%, #a78bfa 100%);
+}
+.grad-sunset {
+  background: linear-gradient(135deg, #fda4af 0%, #fb923c 50%, #fbbf24 100%);
+}
+.grad-forest {
+  background: linear-gradient(135deg, #6ee7b7 0%, #34d399 50%, #a3e635 100%);
+}
+.grad-night {
+  background: linear-gradient(
+    135deg,
+    #1e1b4b 0%,
+    #312e81 40%,
+    #4f46e5 80%,
+    #7c3aed 100%
+  );
+}
+.grad-sakura {
+  background: linear-gradient(135deg, #fce7f3 0%, #fbcfe8 50%, #f9a8d4 100%);
+}
+.grad-ocean {
+  background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 50%, #8b5cf6 100%);
+}
+.grad-autumn {
+  background: linear-gradient(135deg, #dc2626 0%, #ea580c 50%, #d97706 100%);
+}
+.grad-pastel {
+  background: linear-gradient(135deg, #e9d5ff 0%, #fbcfe8 50%, #fef3c7 100%);
+}
+.grad-starry {
+  background: linear-gradient(
+    135deg,
+    #0f172a 0%,
+    #1e3a5f 25%,
+    #3b82f6 50%,
+    #8b5cf6 75%,
+    #c084fc 100%
+  );
+}
+
+/* Masonry layout */
+.masonry-grid {
+  column-count: 2;
+  column-gap: 12px;
+}
+@media (min-width: 640px) {
+  .masonry-grid {
+    column-gap: 16px;
+  }
+}
+@media (min-width: 768px) {
+  .masonry-grid {
+    column-count: 3;
+  }
+}
+@media (min-width: 1024px) {
+  .masonry-grid {
+    column-count: 4;
+  }
+}
+.masonry-item {
+  break-inside: avoid;
+  margin-bottom: 12px;
+}
+@media (min-width: 640px) {
+  .masonry-item {
+    margin-bottom: 16px;
+  }
+}
+
+/* Washi tape decoration */
+.washi-tape {
+  position: absolute;
+  height: 22px;
+  border-radius: 2px;
+  opacity: 0.5;
+  z-index: 5;
+  pointer-events: none;
+}
+
+/* Pushpin decoration */
+.pushpin {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  position: absolute;
+  z-index: 6;
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.2),
+    inset 0 1px 2px rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+}
+.pushpin::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 5px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+}
+.pushpin-red {
+  background: radial-gradient(circle at 40% 35%, #f87171, #dc2626);
+}
+.pushpin-blue {
+  background: radial-gradient(circle at 40% 35%, #60a5fa, #2563eb);
+}
+.pushpin-yellow {
+  background: radial-gradient(circle at 40% 35%, #fbbf24, #d97706);
+}
+
+/* Category badge */
+.badge-book {
+  background: #fef3c7;
+  color: #92400e;
+}
+.badge-music {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+.badge-movie {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+/* Gentle float animation */
+@keyframes gentleFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+.animate-gentle-float {
+  animation: gentleFloat 3s ease-in-out infinite;
+}
+
+/* Brand gradient text */
+.brand-gradient-text {
+  background: linear-gradient(135deg, #a855f7, #ec4899, #f97316);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Tag pill styles */
+.tag-hot {
+  background: linear-gradient(135deg, #fecaca, #fed7aa);
+  color: #9a3412;
+}
+.tag-spring {
+  background: linear-gradient(135deg, #fce7f3, #fbcfe8);
+  color: #9d174d;
+}
+.tag-novel {
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  color: #92400e;
+}
+.tag-music {
+  background: linear-gradient(135deg, #ede9fe, #ddd6fe);
+  color: #5b21b6;
+}
+.tag-movie {
+  background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+  color: #1e40af;
+}

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -4,8 +4,6 @@ import Button from '@mui/material/Button'
 import ErrorMessage from '../components/ErrorMessage'
 import GalleryCard from '../components/GalleryCard'
 import DataCredits from '../components/DataCredits'
-import PageHeader from '../components/PageHeader'
-import PillLinkButton from '../components/PillLinkButton'
 import { useGallery } from '../hooks/useGallery'
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver'
 
@@ -14,18 +12,38 @@ export default function GalleryPage() {
   const sentinelRef = useIntersectionObserver(loadMore)
 
   return (
-    <div
-      className="min-h-screen"
-      style={{
-        background:
-          'linear-gradient(180deg, var(--color-bg) 0%, #f5f0eb 50%, #efe8e0 100%)',
-      }}
-    >
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <div className="mx-auto max-w-5xl px-3 py-4 sm:px-4 sm:py-6 lg:py-8">
-        <PageHeader
-          title="みんなの推し"
-          subtitle="みんなが選んだ推し作品たち"
-        />
+        {/* Header */}
+        <div className="mb-6 text-center sm:mb-8">
+          <h1
+            className="brand-gradient-text mb-2 text-3xl font-extrabold tracking-tight sm:text-4xl"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            さがす
+          </h1>
+          <p
+            className="mx-auto mb-5 max-w-md text-sm sm:text-base"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            みんなが作ったコレクションボード
+          </p>
+
+          {/* Navigation pill */}
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 rounded-full px-4 py-1.5 text-sm font-semibold transition-all duration-200 hover:-translate-y-0.5"
+            style={{
+              color: 'var(--color-primary-dark)',
+              border:
+                '1px solid color-mix(in srgb, var(--color-primary) 30%, transparent)',
+              backgroundColor:
+                'color-mix(in srgb, var(--color-bg) 60%, transparent)',
+            }}
+          >
+            ✨ ボードをつくる
+          </Link>
+        </div>
 
         {/* Loading */}
         {loading && (
@@ -59,7 +77,6 @@ export default function GalleryPage() {
               to="/"
               variant="outlined"
               size="small"
-              className="mt-4"
               sx={{ mt: 2 }}
             >
               作品を選ぶ ✨
@@ -67,10 +84,10 @@ export default function GalleryPage() {
           </div>
         )}
 
-        {/* Gallery Grid */}
+        {/* Masonry Gallery */}
         {!loading && !error && items.length > 0 && (
           <>
-            <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="masonry-grid">
               {items.map((item) => (
                 <GalleryCard key={item.id} {...item} />
               ))}
@@ -103,11 +120,6 @@ export default function GalleryPage() {
             )}
           </>
         )}
-
-        {/* Navigation */}
-        <div className="mt-8 text-center">
-          <PillLinkButton to="/">← 作品を選ぶ ✨</PillLinkButton>
-        </div>
       </div>
 
       <DataCredits />

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -69,10 +69,9 @@ function SearchPage() {
           )}
         </svg>
         <h1
-          className="animate-fade-in-up relative text-3xl font-extrabold tracking-tight sm:text-4xl"
+          className="animate-fade-in-up brand-gradient-text relative text-3xl font-extrabold tracking-tight sm:text-4xl"
           style={{
             fontFamily: 'var(--font-display)',
-            color: 'var(--color-text-primary)',
           }}
         >
           すきコレ
@@ -98,7 +97,7 @@ function SearchPage() {
                 'color-mix(in srgb, var(--color-bg) 60%, transparent)',
             }}
           >
-            みんなの推しを見る 👀
+            🔍 みんなのボードを見る
           </Link>
         </div>
         <div className="animate-fade-in-up animate-delay-400 relative mt-5">


### PR DESCRIPTION
## 概要

Pinterest風の「コレクションボード」UIを導入し、3つの主要画面を刷新します。

## 変更内容

### 🎨 Gallery → 「さがす」ページ (`/gallery`)
- **Masonry レイアウト**: モバイル2列 → タブレット3列 → デスクトップ4列
- **グラデーション背景ヒーロー**: テーマIDに基づく11種のグラデーションをランダム割り当て
- **カード高さバリエーション**: `h-28`〜`h-40` で Pinterest風の不揃い感
- ヘッダーをブランドグラデーション「さがす」に変更

### 📌 Board Detail → コルクボードスタイル (`/s/:id`)
- **コルク背景テクスチャ** (`cork-bg`): SVGフィルタ＋radial-gradient
- **プッシュピン装飾**: 赤・青・黄の3色、radial-gradient＋box-shadow
- **マスキングテープ装飾**: 各カード上部にピンク・ラベンダー・ブルー
- **カードの微傾き**: `rotate(-1.5deg)` 〜 `rotate(1deg)` で手作り感

### ✨ Search → ブランディング更新 (`/`)
- 「すきコレ」ロゴをグラデーションテキスト化 (`brand-gradient-text`)
- ギャラリーリンクを「🔍 みんなのボードを見る」に変更

### 🧱 共通CSS追加 (`index.css`)
- `cork-bg`, `grad-*` (11種), `masonry-grid`, `masonry-item`
- `washi-tape`, `pushpin`, `pushpin-red/blue/yellow`
- `badge-book/music/movie`, `brand-gradient-text`, `tag-*`
- `animate-gentle-float`

## テスト
- ✅ `npm run lint` — 0 errors
- ✅ `npm run format:check` — pass
- ✅ `npm run typecheck` — pass
- ✅ `npm run test` — 595/595 passed

## スクリーンショット

### Desktop — Gallery (Masonry 4列)
デスクトップではPinterest風4カラムMasonryレイアウト

### Desktop — Board Detail (コルクボード)
コルクボード背景にプッシュピン・マスキングテープ装飾付きワークカード

### Mobile — Gallery (Masonry 2列)
モバイルでは2カラムMasonryで表示

## 備考
- アカウント概念は導入せず、既存の3ページ構成(Search/Gallery/Top3)を維持
- バックエンドの変更なし — フロントのUI/スタイルのみの変更
- レスポンシブ版モックアップも `mockups/plan-c-responsive.html` に追加
