### PR TITLE
refactor: shares.ts の文字列型チェック繰り返しをヘルパー関数 str() に抽出

### DIFF
--- a/src/server/routes/shares.ts
+++ b/src/server/routes/shares.ts
@@ -13,6 +13,8 @@ function isValidBody(body: unknown): body is {
   return typeof body === 'object' && body !== null && !Array.isArray(body)
 }
 
+const str = (v: unknown): string => (typeof v === 'string' ? v : '')
+
 export type SharesAppOptions = {
   adminApiKey?: string
   ttlSeconds?: number
@@ -59,13 +61,13 @@ export function createSharesApp(dbPath: string, options?: SharesAppOptions) {
     }
 
     const params: ShareParams = {
-      theme: typeof body.theme === 'string' ? body.theme : '',
-      bookId: typeof body.bookId === 'string' ? body.bookId : '',
-      musicId: typeof body.musicId === 'string' ? body.musicId : '',
-      movieId: typeof body.movieId === 'string' ? body.movieId : '',
-      bookThumb: typeof body.bookThumb === 'string' ? body.bookThumb : '',
-      musicThumb: typeof body.musicThumb === 'string' ? body.musicThumb : '',
-      movieThumb: typeof body.movieThumb === 'string' ? body.movieThumb : '',
+      theme: str(body.theme),
+      bookId: str(body.bookId),
+      musicId: str(body.musicId),
+      movieId: str(body.movieId),
+      bookThumb: str(body.bookThumb),
+      musicThumb: str(body.musicThumb),
+      movieThumb: str(body.movieThumb),
     }
 
     if (!params.bookId && !params.musicId && !params.movieId) {


### PR DESCRIPTION
## 概要

`shares.ts` で7回繰り返されていた `typeof body.X === 'string' ? body.X : ''` パターンをヘルパー関数 `str()` に抽出。

## 変更内容

- モジュールスコープに `str(v: unknown): string` ヘルパー関数を追加
- POST ハンドラ内の7箇所の型チェックパターンを `str()` 呼び出しに置換

## 確認事項

- [x] lint 通過
- [x] format:check 通過
- [x] typecheck 通過
- [x] 全605テスト通過（shares.test.ts 25テスト含む）

Closes #209