### PR TITLE
feat: シェアページのモバイル表示を横スクロールカルーセルに改善

### DIFF
--- a/src/components/MobileCarousel.tsx
+++ b/src/components/MobileCarousel.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef, useCallback, type ReactNode } from 'react'
+
+type Props = {
+  children: ReactNode[]
+}
+
+/**
+ * Mobile-only horizontal carousel with swipe + dot indicators.
+ * Renders children in a scrollable track, snapping one card at a time.
+ */
+export default function MobileCarousel({ children }: Props) {
+  const [current, setCurrent] = useState(0)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const touchStartX = useRef(0)
+  const touchStartY = useRef(0)
+  const count = children.length
+
+  const goTo = useCallback(
+    (index: number) => {
+      const clamped = Math.max(0, Math.min(count - 1, index))
+      setCurrent(clamped)
+    },
+    [count],
+  )
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+    touchStartY.current = e.touches[0].clientY
+  }, [])
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      const dx = touchStartX.current - e.changedTouches[0].clientX
+      const dy = touchStartY.current - e.changedTouches[0].clientY
+      // Only swipe horizontally if dx > dy (prevent hijacking vertical scroll)
+      if (Math.abs(dx) > 40 && Math.abs(dx) > Math.abs(dy)) {
+        goTo(current + (dx > 0 ? 1 : -1))
+      }
+    },
+    [current, goTo],
+  )
+
+  return (
+    <div className="mobile-carousel">
+      <div
+        className="mobile-carousel-track"
+        ref={trackRef}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        style={{ transform: `translateX(-${current * 100}%)` }}
+      >
+        {children.map((child, i) => (
+          <div className="mobile-carousel-slide" key={i}>
+            {child}
+          </div>
+        ))}
+      </div>
+
+      {/* Dot indicators */}
+      <div className="mobile-carousel-dots">
+        {Array.from({ length: count }, (_, i) => (
+          <button
+            key={i}
+            className={`mobile-carousel-dot${i === current ? ' active' : ''}`}
+            onClick={() => goTo(i)}
+            aria-label={`${i + 1}枚目を表示`}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Top3Content.tsx
+++ b/src/components/Top3Content.tsx
@@ -1,12 +1,14 @@
 import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import Button from '@mui/material/Button'
+import useMediaQuery from '@mui/material/useMediaQuery'
 import { buildEditUrl } from '../utils/url-params'
 import PillLinkButton from './PillLinkButton'
 import ErrorMessage from './ErrorMessage'
 import ShareButtons from './ShareButtons'
 import Top3Image from './Top3Image'
 import WorkCard from './WorkCard'
+import MobileCarousel from './MobileCarousel'
 import { useWorkFetch } from '../hooks/useWorkFetch'
 import { usePreGeneratedImage } from '../hooks/usePreGeneratedImage'
 import { useMergedRef } from '../hooks/useMergedRef'
@@ -54,6 +56,7 @@ export default function Top3Content({
   existingShareId,
   readOnly,
 }: Props) {
+  const isMobile = useMediaQuery('(max-width:639px)')
   const captureRef = useRef<HTMLDivElement>(null)
   const [captureElement, setCaptureElement] = useState<HTMLDivElement | null>(
     null,
@@ -142,60 +145,121 @@ export default function Top3Content({
             aria-hidden="true"
           />
 
-          {/* Work cards — screen-2 flex layout with rotation */}
-          <div className="flex flex-col items-center gap-5 sm:flex-row sm:flex-wrap sm:justify-center sm:gap-6">
-            <div
-              className="animate-fade-in-up relative"
-              style={{ transform: 'rotate(-2deg)' }}
-            >
-              <WashiTape
-                color="linear-gradient(90deg, #fbcfe8, #fce7f3)"
-                rotate="2deg"
-                left="30%"
-              />
-              <WorkCard
-                work={book.data}
-                loading={book.loading}
-                error={book.error}
-                label="📚 本"
-                onRetry={book.error ? book.retry : undefined}
-              />
+          {/* Work cards */}
+          {isMobile ? (
+            <MobileCarousel>
+              {[
+                <div
+                  key="book"
+                  className="animate-fade-in-up relative"
+                  style={{ transform: 'rotate(-2deg)' }}
+                >
+                  <WashiTape
+                    color="linear-gradient(90deg, #fbcfe8, #fce7f3)"
+                    rotate="2deg"
+                    left="30%"
+                  />
+                  <WorkCard
+                    work={book.data}
+                    loading={book.loading}
+                    error={book.error}
+                    label="📚 本"
+                    onRetry={book.error ? book.retry : undefined}
+                  />
+                </div>,
+                <div
+                  key="music"
+                  className="animate-fade-in-up relative"
+                  style={{ transform: 'rotate(1.5deg)' }}
+                >
+                  <WashiTape
+                    color="linear-gradient(90deg, #ddd6fe, #ede9fe)"
+                    rotate="-3deg"
+                    left="25%"
+                  />
+                  <WorkCard
+                    work={music.data}
+                    loading={music.loading}
+                    error={music.error}
+                    label="🎵 音楽"
+                    onRetry={music.error ? music.retry : undefined}
+                  />
+                </div>,
+                <div
+                  key="movie"
+                  className="animate-fade-in-up relative"
+                  style={{ transform: 'rotate(-0.8deg)' }}
+                >
+                  <WashiTape
+                    color="linear-gradient(90deg, #bfdbfe, #dbeafe)"
+                    rotate="1deg"
+                    left="35%"
+                  />
+                  <WorkCard
+                    work={movie.data}
+                    loading={movie.loading}
+                    error={movie.error}
+                    label="🎬 映画"
+                    onRetry={movie.error ? movie.retry : undefined}
+                  />
+                </div>,
+              ]}
+            </MobileCarousel>
+          ) : (
+            <div className="flex flex-row flex-wrap justify-center gap-6">
+              <div
+                className="animate-fade-in-up relative"
+                style={{ transform: 'rotate(-2deg)' }}
+              >
+                <WashiTape
+                  color="linear-gradient(90deg, #fbcfe8, #fce7f3)"
+                  rotate="2deg"
+                  left="30%"
+                />
+                <WorkCard
+                  work={book.data}
+                  loading={book.loading}
+                  error={book.error}
+                  label="📚 本"
+                  onRetry={book.error ? book.retry : undefined}
+                />
+              </div>
+              <div
+                className="animate-fade-in-up animate-delay-100 relative"
+                style={{ transform: 'rotate(1.5deg)', marginTop: 30 }}
+              >
+                <WashiTape
+                  color="linear-gradient(90deg, #ddd6fe, #ede9fe)"
+                  rotate="-3deg"
+                  left="25%"
+                />
+                <WorkCard
+                  work={music.data}
+                  loading={music.loading}
+                  error={music.error}
+                  label="🎵 音楽"
+                  onRetry={music.error ? music.retry : undefined}
+                />
+              </div>
+              <div
+                className="animate-fade-in-up animate-delay-200 relative"
+                style={{ transform: 'rotate(-0.8deg)' }}
+              >
+                <WashiTape
+                  color="linear-gradient(90deg, #bfdbfe, #dbeafe)"
+                  rotate="1deg"
+                  left="35%"
+                />
+                <WorkCard
+                  work={movie.data}
+                  loading={movie.loading}
+                  error={movie.error}
+                  label="🎬 映画"
+                  onRetry={movie.error ? movie.retry : undefined}
+                />
+              </div>
             </div>
-            <div
-              className="animate-fade-in-up animate-delay-100 relative"
-              style={{ transform: 'rotate(1.5deg)', marginTop: 30 }}
-            >
-              <WashiTape
-                color="linear-gradient(90deg, #ddd6fe, #ede9fe)"
-                rotate="-3deg"
-                left="25%"
-              />
-              <WorkCard
-                work={music.data}
-                loading={music.loading}
-                error={music.error}
-                label="🎵 音楽"
-                onRetry={music.error ? music.retry : undefined}
-              />
-            </div>
-            <div
-              className="animate-fade-in-up animate-delay-200 relative"
-              style={{ transform: 'rotate(-0.8deg)' }}
-            >
-              <WashiTape
-                color="linear-gradient(90deg, #bfdbfe, #dbeafe)"
-                rotate="1deg"
-                left="35%"
-              />
-              <WorkCard
-                work={movie.data}
-                loading={movie.loading}
-                error={movie.error}
-                label="🎬 映画"
-                onRetry={movie.error ? movie.retry : undefined}
-              />
-            </div>
-          </div>
+          )}
         </div>
 
         {showImage && (

--- a/src/index.css
+++ b/src/index.css
@@ -480,6 +480,46 @@ body {
     width: 240px;
   }
 }
+
+/* ===== Mobile Carousel ===== */
+.mobile-carousel {
+  overflow: hidden;
+  position: relative;
+}
+.mobile-carousel-track {
+  display: flex;
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.mobile-carousel-slide {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  padding: 8px 16px;
+}
+.mobile-carousel-slide .work-card-board {
+  width: 240px;
+}
+.mobile-carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+.mobile-carousel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: var(--color-border, #ccc);
+  transition: all 0.25s ease;
+}
+.mobile-carousel-dot.active {
+  background: var(--color-primary, #a855f7);
+  width: 22px;
+  border-radius: 4px;
+}
 .work-card-board:hover {
   box-shadow: 0 12px 36px var(--color-primary-a15) !important;
 }


### PR DESCRIPTION
## 概要
モバイル表示時にワークカードが縦に3枚並んでスクロール量が多かった問題を、横スワイプのカルーセルUIに変更。

## 変更内容
- **`MobileCarousel.tsx`** (新規): スワイプ＋ドットインジケーター付きカルーセルコンポーネント
- **`Top3Content.tsx`**: モバイル(<640px)でカルーセル、デスクトップは従来レイアウト維持
- **`index.css`**: カルーセルのスタイル追加

## 動作
- 横スワイプで 本 → 音楽 → 映画 を切り替え
- ドットタップでもジャンプ可能
- 縦スクロールを邪魔しないよう、水平方向の移動量が大きいときだけスワイプ判定
- デスクトップ表示は変更なし

## スクリーンショット
### Before (縦並び)
カードが縦に3枚並び、スクロール量が多い

### After (カルーセル)
1枚ずつ表示、スワイプで切り替え、ドットインジケーターで現在位置を表示
