### PR TITLE
fix: SelectionArea枠幅を他セクションと統一

### DIFF
--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -128,14 +128,16 @@ function SearchPage() {
       {/* Selection Area - Sticky bottom tray */}
       <div
         data-testid="selection-area-wrapper"
-        className="sticky bottom-0 z-30 mx-auto max-w-3xl p-3 sm:p-4 clay"
+        className="sticky bottom-0 z-30 mx-auto max-w-3xl px-3 sm:px-4"
       >
-        <SelectionArea
-          theme={theme}
-          onBeforeCreate={handleBeforeCreate}
-          onCompleteChange={handleCompleteChange}
-          onSlotClick={setActiveTab}
-        />
+        <div className="clay p-3 sm:p-4">
+          <SelectionArea
+            theme={theme}
+            onBeforeCreate={handleBeforeCreate}
+            onCompleteChange={handleCompleteChange}
+            onSlotClick={setActiveTab}
+          />
+        </div>
       </div>
 
       <DataCredits />


### PR DESCRIPTION
## 変更内容

SelectionArea（あなたのセレクト）の枠幅が、検索バーや検索結果エリアより広くなっていた問題を修正。

## 原因

SelectionAreaのラッパー div に `clay` クラスと `p-3` が直接適用されていたため、他セクションの構造（`px-3` 外側ラッパー → `clay` 内側ボックス）と異なっていた。

## 修正

他セクションと同じく `px-3` の外側ラッパーの中に `clay` ボックスを配置する構造に統一。

## テスト

- `npm run test` 全612件パス ✅
- `npm run lint` クリーン ✅
- `npm run format` 実行済み ✅