### PR TITLE
feat: シェア画像の縦長（9:16）テンプレート対応

### DIFF
--- a/src/components/AspectRatioSelector.test.tsx
+++ b/src/components/AspectRatioSelector.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '../test/test-utils'
+import { AspectRatioSelector } from './AspectRatioSelector'
+
+describe('AspectRatioSelector', () => {
+  it('renders with landscape selected by default', () => {
+    const onChange = vi.fn()
+    render(<AspectRatioSelector value="landscape" onChange={onChange} />)
+    expect(screen.getByTestId('aspect-ratio-selector')).toBeInTheDocument()
+    expect(screen.getByText('画像サイズ:')).toBeInTheDocument()
+    expect(screen.getByText('横長 1:1')).toBeInTheDocument()
+    expect(screen.getByText('縦長 9:16')).toBeInTheDocument()
+  })
+
+  it('calls onChange when portrait is clicked', () => {
+    const onChange = vi.fn()
+    render(<AspectRatioSelector value="landscape" onChange={onChange} />)
+    fireEvent.click(screen.getByText('縦長 9:16'))
+    expect(onChange).toHaveBeenCalledWith('portrait')
+  })
+
+  it('calls onChange when landscape is clicked', () => {
+    const onChange = vi.fn()
+    render(<AspectRatioSelector value="portrait" onChange={onChange} />)
+    fireEvent.click(screen.getByText('横長 1:1'))
+    expect(onChange).toHaveBeenCalledWith('landscape')
+  })
+
+  it('does not call onChange when already selected value is clicked', () => {
+    const onChange = vi.fn()
+    render(<AspectRatioSelector value="landscape" onChange={onChange} />)
+    fireEvent.click(screen.getByText('横長 1:1'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/AspectRatioSelector.tsx
+++ b/src/components/AspectRatioSelector.tsx
@@ -1,0 +1,83 @@
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import CropLandscapeIcon from '@mui/icons-material/CropLandscape'
+import CropPortraitIcon from '@mui/icons-material/CropPortrait'
+import type { AspectRatio } from '../constants/image-layout'
+
+type AspectRatioSelectorProps = {
+  value: AspectRatio
+  onChange: (value: AspectRatio) => void
+}
+
+export function AspectRatioSelector({
+  value,
+  onChange,
+}: AspectRatioSelectorProps) {
+  return (
+    <div
+      data-testid="aspect-ratio-selector"
+      className="mb-4 flex items-center justify-center gap-2"
+    >
+      <span
+        className="text-xs font-medium"
+        style={{ color: 'var(--color-text-secondary)' }}
+      >
+        画像サイズ:
+      </span>
+      <ToggleButtonGroup
+        value={value}
+        exclusive
+        size="small"
+        onChange={(_, newValue: AspectRatio | null) => {
+          if (newValue !== null) {
+            onChange(newValue)
+          }
+        }}
+        sx={{
+          '& .MuiToggleButton-root': {
+            border: '1px solid var(--color-border)',
+            borderRadius: '9999px',
+            px: 1.5,
+            py: 0.25,
+            fontSize: '0.7rem',
+            fontWeight: 600,
+            letterSpacing: '0.03em',
+            textTransform: 'none',
+            color: 'var(--color-text-secondary)',
+            transition: 'all 0.2s ease',
+            '&:hover': {
+              background:
+                'color-mix(in srgb, var(--color-primary) 6%, transparent)',
+            },
+            '&.Mui-selected': {
+              color: 'var(--color-surface)',
+              backgroundColor: 'var(--color-primary-dark)',
+              borderColor: 'transparent',
+              '&:hover': {
+                backgroundColor: 'var(--color-primary-dark)',
+                filter: 'brightness(1.1)',
+              },
+            },
+          },
+          '& .MuiToggleButtonGroup-grouped': {
+            borderRadius: '9999px !important',
+            mx: 0.25,
+            border: '1px solid var(--color-border) !important',
+            '&.Mui-selected': {
+              border: '1px solid transparent !important',
+            },
+          },
+        }}
+      >
+        <ToggleButton value="landscape" aria-label="横長 (1:1)">
+          <CropLandscapeIcon sx={{ fontSize: 16, mr: 0.5 }} />
+          横長 1:1
+        </ToggleButton>
+        <ToggleButton value="portrait" aria-label="縦長 (9:16)">
+          <CropPortraitIcon sx={{ fontSize: 16, mr: 0.5 }} />
+          縦長 9:16
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </div>
+  )
+}

--- a/src/components/ImageSlot.tsx
+++ b/src/components/ImageSlot.tsx
@@ -1,10 +1,11 @@
 import type { SearchResultItem, MediaCategory } from '../types/common'
-import type { SlotPosition } from '../constants/image-layout'
+import type { AnySlotPosition } from '../constants/image-layout'
 import {
   CATEGORY_COLORS,
   CATEGORY_BORDER_COLORS,
   CATEGORY_LABELS,
   SLOT_STYLES,
+  VERTICAL_SLOT_STYLES,
 } from '../constants/image-layout'
 import {
   CANVAS_DARK,
@@ -16,12 +17,24 @@ import { proxyImageUrl } from '../utils/proxy-image-url'
 export type ImageSlotProps = {
   item: SearchResultItem | null
   category: MediaCategory
-  slot: SlotPosition
+  slot: AnySlotPosition
   theme?: string
 }
 
+function isTopSlot(slot: AnySlotPosition): boolean {
+  return slot === 'top' || slot === 'v-top'
+}
+
+function getSlotStyle(slot: AnySlotPosition) {
+  if (slot.startsWith('v-')) {
+    return VERTICAL_SLOT_STYLES[slot as keyof typeof VERTICAL_SLOT_STYLES]
+  }
+  return SLOT_STYLES[slot as keyof typeof SLOT_STYLES]
+}
+
 export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
-  const style = SLOT_STYLES[slot]
+  const style = getSlotStyle(slot)
+  const isTop = isTopSlot(slot)
   const color = CATEGORY_COLORS[category]
   const borderColor = CATEGORY_BORDER_COLORS[category]
 
@@ -83,7 +96,7 @@ export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           backgroundRepeat: 'no-repeat',
-          filter: slot === 'top' ? 'none' : 'brightness(0.7)',
+          filter: isTop ? 'none' : 'brightness(0.7)',
         }}
       />
 
@@ -112,7 +125,7 @@ export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
       >
         {/* Top: theme (only on top slot) or category badge */}
         <div>
-          {slot === 'top' && theme ? (
+          {isTop && theme ? (
             <div
               style={{
                 fontSize: 14,
@@ -128,12 +141,12 @@ export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
               style={{
                 display: 'inline-block',
                 alignSelf: 'flex-start',
-                fontSize: slot === 'top' ? 11 : 10,
+                fontSize: isTop ? 11 : 10,
                 fontWeight: 700,
                 color,
                 letterSpacing: 3,
                 textTransform: 'uppercase' as const,
-                padding: slot === 'top' ? '4px 12px' : '3px 10px',
+                padding: isTop ? '4px 12px' : '3px 10px',
                 background: 'rgba(0,0,0,0.4)',
                 border: `1px solid ${borderColor}`,
                 borderRadius: 4,
@@ -147,7 +160,7 @@ export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
         {/* Bottom: work info */}
         <div>
           {/* Category badge (show below theme on top slot) */}
-          {slot === 'top' && theme && (
+          {isTop && theme && (
             <div
               style={{
                 display: 'inline-block',
@@ -181,7 +194,7 @@ export function ImageSlot({ item, category, slot, theme }: ImageSlotProps) {
             style={{
               fontSize: style.subtitleSize,
               color: 'rgba(255,255,255,0.55)',
-              marginTop: slot === 'top' ? 8 : 6,
+              marginTop: isTop ? 8 : 6,
               letterSpacing: 1,
               textShadow: '0 1px 8px rgba(0,0,0,0.5)',
             }}

--- a/src/components/LayoutSelector.tsx
+++ b/src/components/LayoutSelector.tsx
@@ -1,10 +1,17 @@
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import type { MediaCategory } from '../types/common'
-import type { LayoutConfig, SlotPosition } from '../constants/image-layout'
+import type {
+  LayoutConfig,
+  SlotPosition,
+  VerticalLayoutConfig,
+  VerticalSlotPosition,
+} from '../constants/image-layout'
 import {
   SLOT_LABELS,
   SLOT_POSITIONS,
+  VERTICAL_SLOT_LABELS,
+  VERTICAL_SLOT_POSITIONS,
   CATEGORY_LABELS,
   CATEGORY_COLORS,
 } from '../constants/image-layout'
@@ -14,6 +21,11 @@ const CATEGORIES: MediaCategory[] = ['book', 'music', 'movie']
 type LayoutSelectorProps = {
   layout: LayoutConfig
   onLayoutChange: (slot: SlotPosition, category: MediaCategory) => void
+}
+
+type VerticalLayoutSelectorProps = {
+  layout: VerticalLayoutConfig
+  onLayoutChange: (slot: VerticalSlotPosition, category: MediaCategory) => void
 }
 
 export function LayoutSelector({
@@ -32,6 +44,92 @@ export function LayoutSelector({
             style={{ color: 'var(--color-text-secondary)' }}
           >
             {SLOT_LABELS[slot]}:
+          </span>
+          <ToggleButtonGroup
+            data-testid={`layout-slot-${slot}`}
+            value={layout[slot]}
+            exclusive
+            size="small"
+            onChange={(_, value: MediaCategory | null) => {
+              if (value !== null) {
+                onLayoutChange(slot, value)
+              }
+            }}
+            sx={{
+              '& .MuiToggleButton-root': {
+                border: '1px solid var(--color-border)',
+                borderRadius: '9999px',
+                px: 1.5,
+                py: 0.25,
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                letterSpacing: '0.03em',
+                textTransform: 'none',
+                color: 'var(--color-text-secondary)',
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  background:
+                    'color-mix(in srgb, var(--color-primary) 6%, transparent)',
+                },
+                '&.Mui-selected': {
+                  color: 'var(--color-surface)',
+                  borderColor: 'transparent',
+                  '&:hover': {
+                    filter: 'brightness(1.1)',
+                  },
+                },
+              },
+              '& .MuiToggleButtonGroup-grouped': {
+                borderRadius: '9999px !important',
+                mx: 0.25,
+                border: '1px solid var(--color-border) !important',
+                '&.Mui-selected': {
+                  border: '1px solid transparent !important',
+                },
+              },
+            }}
+          >
+            {CATEGORIES.map((category) => (
+              <ToggleButton
+                key={category}
+                value={category}
+                sx={{
+                  '&.Mui-selected': {
+                    backgroundColor: CATEGORY_COLORS[category],
+                  },
+                }}
+              >
+                <span
+                  data-testid="color-indicator"
+                  className="mr-1 inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: CATEGORY_COLORS[category] }}
+                />
+                {CATEGORY_LABELS[category]}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function VerticalLayoutSelector({
+  layout,
+  onLayoutChange,
+}: VerticalLayoutSelectorProps) {
+  return (
+    <div
+      data-testid="layout-selector"
+      className="mb-4 flex flex-wrap items-center justify-center gap-4"
+    >
+      {VERTICAL_SLOT_POSITIONS.map((slot) => (
+        <div key={slot} className="flex items-center gap-2">
+          <span
+            className="text-xs font-medium"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {VERTICAL_SLOT_LABELS[slot]}:
           </span>
           <ToggleButtonGroup
             data-testid={`layout-slot-${slot}`}

--- a/src/components/Top3Image.test.tsx
+++ b/src/components/Top3Image.test.tsx
@@ -604,6 +604,137 @@ describe('Top3Image', () => {
     })
   })
 
+  describe('portrait mode (9:16)', () => {
+    it('renders 1080x1920 capture area when portrait is selected', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+
+      // Switch to portrait
+      fireEvent.click(screen.getByText('縦長 9:16'))
+
+      const captureArea = screen.getByTestId('top3-image-capture')
+      expect(captureArea.style.width).toBe('1080px')
+      expect(captureArea.style.height).toBe('1920px')
+    })
+
+    it('renders aspect ratio selector', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+      expect(screen.getByTestId('aspect-ratio-selector')).toBeInTheDocument()
+    })
+
+    it('defaults to landscape (1:1)', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+      const captureArea = screen.getByTestId('top3-image-capture')
+      expect(captureArea.style.width).toBe('1080px')
+      expect(captureArea.style.height).toBe('1080px')
+    })
+
+    it('shows three vertical slots in portrait mode', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('縦長 9:16'))
+
+      expect(screen.getByTestId('slot-v-top')).toBeInTheDocument()
+      expect(screen.getByTestId('slot-v-middle')).toBeInTheDocument()
+      expect(screen.getByTestId('slot-v-bottom')).toBeInTheDocument()
+    })
+
+    it('displays all work titles in portrait mode', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('縦長 9:16'))
+
+      expect(screen.getByText('Test Album')).toBeInTheDocument()
+      expect(screen.getByText('Test Book')).toBeInTheDocument()
+      expect(screen.getByText('Test Movie')).toBeInTheDocument()
+    })
+
+    it('shows landscape slots when switching back from portrait', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+
+      // Switch to portrait
+      fireEvent.click(screen.getByText('縦長 9:16'))
+      expect(screen.getByTestId('slot-v-top')).toBeInTheDocument()
+
+      // Switch back to landscape
+      fireEvent.click(screen.getByText('横長 1:1'))
+      expect(screen.getByTestId('slot-top')).toBeInTheDocument()
+      expect(screen.getByTestId('slot-bottom-left')).toBeInTheDocument()
+      expect(screen.getByTestId('slot-bottom-right')).toBeInTheDocument()
+    })
+
+    it('shows theme text in portrait mode top slot', () => {
+      render(
+        <Top3Image
+          theme="雨の日に楽しむ"
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+        />,
+      )
+
+      fireEvent.click(screen.getByText('縦長 9:16'))
+
+      expect(screen.getByText('「 雨の日に楽しむ 」')).toBeInTheDocument()
+    })
+
+    it('hides aspect ratio selector in readOnly mode', () => {
+      render(
+        <Top3Image
+          theme=""
+          book={mockBook}
+          music={mockMusic}
+          movie={mockMovie}
+          readOnly
+        />,
+      )
+      expect(
+        screen.queryByTestId('aspect-ratio-selector'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe('readOnly mode', () => {
     it('hides layout selector when readOnly is true', () => {
       render(

--- a/src/components/Top3Image.tsx
+++ b/src/components/Top3Image.tsx
@@ -1,16 +1,26 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import DownloadIcon from '@mui/icons-material/Download'
 import type { SearchResultItem, MediaCategory } from '../types/common'
-import { IMAGE_SIZE, HALF, SEP } from '../constants/image-layout'
+import {
+  IMAGE_SIZE,
+  HALF,
+  SEP,
+  PORTRAIT_WIDTH,
+  PORTRAIT_HEIGHT,
+  VERTICAL_SLOT_POSITIONS,
+  VERTICAL_SLOT_STYLES,
+} from '../constants/image-layout'
+import type { AspectRatio } from '../constants/image-layout'
 import { CANVAS_DARK } from '../constants/image-colors'
 import { useImageCapture } from '../hooks/useImageCapture'
-import { useLayoutSwap } from '../hooks/useLayoutSwap'
+import { useLayoutSwap, useVerticalLayoutSwap } from '../hooks/useLayoutSwap'
 import { useMergedRef } from '../hooks/useMergedRef'
 import { ImageSlot } from './ImageSlot'
 import { StatusSnackbar } from './StatusSnackbar'
-import { LayoutSelector } from './LayoutSelector'
+import { LayoutSelector, VerticalLayoutSelector } from './LayoutSelector'
+import { AspectRatioSelector } from './AspectRatioSelector'
 
 type Top3ImageProps = {
   theme: string
@@ -29,6 +39,12 @@ function Top3Image({
   captureRef: externalCaptureRef,
   readOnly,
 }: Top3ImageProps) {
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>('landscape')
+
+  const isPortrait = aspectRatio === 'portrait'
+  const canvasWidth = isPortrait ? PORTRAIT_WIDTH : IMAGE_SIZE
+  const canvasHeight = isPortrait ? PORTRAIT_HEIGHT : IMAGE_SIZE
+
   const {
     captureRef: internalCaptureRef,
     containerRef,
@@ -39,14 +55,17 @@ function Top3Image({
     setSuccessOpen,
     scale,
     handleDownload,
-  } = useImageCapture(theme)
+  } = useImageCapture(theme, { width: canvasWidth, height: canvasHeight })
 
   const captureRefCallback = useMergedRef(
     internalCaptureRef,
     externalCaptureRef,
   )
 
-  const { layout, handleLayoutChange } = useLayoutSwap()
+  const { layout: landscapeLayout, handleLayoutChange: handleLandscapeChange } =
+    useLayoutSwap()
+  const { layout: verticalLayout, handleLayoutChange: handleVerticalChange } =
+    useVerticalLayoutSwap()
 
   const items: Record<MediaCategory, SearchResultItem | null> = {
     book,
@@ -57,15 +76,28 @@ function Top3Image({
   return (
     <div>
       {!readOnly && (
-        <LayoutSelector layout={layout} onLayoutChange={handleLayoutChange} />
+        <>
+          <AspectRatioSelector value={aspectRatio} onChange={setAspectRatio} />
+          {isPortrait ? (
+            <VerticalLayoutSelector
+              layout={verticalLayout}
+              onLayoutChange={handleVerticalChange}
+            />
+          ) : (
+            <LayoutSelector
+              layout={landscapeLayout}
+              onLayoutChange={handleLandscapeChange}
+            />
+          )}
+        </>
       )}
 
       {/* Capture target */}
       <div ref={containerRef} style={{ overflow: 'hidden', maxWidth: '100%' }}>
         <div
           style={{
-            width: IMAGE_SIZE * scale,
-            height: IMAGE_SIZE * scale,
+            width: canvasWidth * scale,
+            height: canvasHeight * scale,
             margin: '0 auto',
             overflow: 'hidden',
           }}
@@ -74,8 +106,8 @@ function Top3Image({
             ref={captureRefCallback}
             data-testid="top3-image-capture"
             style={{
-              width: IMAGE_SIZE,
-              height: IMAGE_SIZE,
+              width: canvasWidth,
+              height: canvasHeight,
               background: CANVAS_DARK,
               position: 'relative',
               overflow: 'hidden',
@@ -85,53 +117,87 @@ function Top3Image({
               transform: `scale(${scale})`,
             }}
           >
-            {/* Top slot */}
-            <ImageSlot
-              item={items[layout.top]}
-              category={layout.top}
-              slot="top"
-              theme={theme}
-            />
+            {isPortrait ? (
+              /* Portrait (9:16) layout: 3 stacked vertically */
+              <>
+                {VERTICAL_SLOT_POSITIONS.map((slot, idx) => (
+                  <React.Fragment key={slot}>
+                    <ImageSlot
+                      item={items[verticalLayout[slot]]}
+                      category={verticalLayout[slot]}
+                      slot={slot}
+                      theme={idx === 0 ? theme : undefined}
+                    />
+                    {idx < 2 && (
+                      <div
+                        style={{
+                          position: 'absolute',
+                          top:
+                            VERTICAL_SLOT_STYLES[slot].top +
+                            VERTICAL_SLOT_STYLES[slot].height,
+                          left: 0,
+                          right: 0,
+                          height: SEP,
+                          background: 'rgba(255,255,255,0.06)',
+                          zIndex: 10,
+                        }}
+                      />
+                    )}
+                  </React.Fragment>
+                ))}
+              </>
+            ) : (
+              /* Landscape (1:1) layout */
+              <>
+                {/* Top slot */}
+                <ImageSlot
+                  item={items[landscapeLayout.top]}
+                  category={landscapeLayout.top}
+                  slot="top"
+                  theme={theme}
+                />
 
-            {/* Horizontal separator */}
-            <div
-              style={{
-                position: 'absolute',
-                top: HALF,
-                left: 0,
-                right: 0,
-                height: SEP,
-                background: 'rgba(255,255,255,0.06)',
-                zIndex: 10,
-              }}
-            />
+                {/* Horizontal separator */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: HALF,
+                    left: 0,
+                    right: 0,
+                    height: SEP,
+                    background: 'rgba(255,255,255,0.06)',
+                    zIndex: 10,
+                  }}
+                />
 
-            {/* Bottom-left slot */}
-            <ImageSlot
-              item={items[layout['bottom-left']]}
-              category={layout['bottom-left']}
-              slot="bottom-left"
-            />
+                {/* Bottom-left slot */}
+                <ImageSlot
+                  item={items[landscapeLayout['bottom-left']]}
+                  category={landscapeLayout['bottom-left']}
+                  slot="bottom-left"
+                />
 
-            {/* Vertical separator */}
-            <div
-              style={{
-                position: 'absolute',
-                top: HALF + SEP,
-                left: HALF - SEP / 2,
-                width: SEP,
-                height: HALF - SEP,
-                background: 'rgba(255,255,255,0.06)',
-                zIndex: 10,
-              }}
-            />
+                {/* Vertical separator */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: HALF + SEP,
+                    left: HALF - SEP / 2,
+                    width: SEP,
+                    height: HALF - SEP,
+                    background: 'rgba(255,255,255,0.06)',
+                    zIndex: 10,
+                  }}
+                />
 
-            {/* Bottom-right slot */}
-            <ImageSlot
-              item={items[layout['bottom-right']]}
-              category={layout['bottom-right']}
-              slot="bottom-right"
-            />
+                {/* Bottom-right slot */}
+                <ImageSlot
+                  item={items[landscapeLayout['bottom-right']]}
+                  category={landscapeLayout['bottom-right']}
+                  slot="bottom-right"
+                />
+              </>
+            )}
 
             {/* Branding & Data Credits */}
             <div

--- a/src/constants/image-layout.test.ts
+++ b/src/constants/image-layout.test.ts
@@ -3,15 +3,26 @@ import {
   IMAGE_SIZE,
   HALF,
   SEP,
+  PORTRAIT_WIDTH,
+  PORTRAIT_HEIGHT,
   CATEGORY_COLORS,
   CATEGORY_BORDER_COLORS,
   NO_IMAGE_SRC,
   DEFAULT_LAYOUT,
+  DEFAULT_VERTICAL_LAYOUT,
   SLOT_LABELS,
+  VERTICAL_SLOT_LABELS,
   CATEGORY_LABELS,
   SLOT_STYLES,
+  VERTICAL_SLOT_STYLES,
+  VERTICAL_SLOT_POSITIONS,
 } from './image-layout'
-import type { SlotPosition, LayoutConfig } from './image-layout'
+import type {
+  SlotPosition,
+  VerticalSlotPosition,
+  LayoutConfig,
+  VerticalLayoutConfig,
+} from './image-layout'
 
 describe('image-layout constants', () => {
   describe('dimensions', () => {
@@ -109,6 +120,61 @@ describe('image-layout constants', () => {
     it('exports SlotPosition type correctly', () => {
       const slot: SlotPosition = 'top'
       expect(SLOT_STYLES[slot]).toBeDefined()
+    })
+  })
+
+  describe('portrait dimensions', () => {
+    it('PORTRAIT_WIDTH is 1080', () => {
+      expect(PORTRAIT_WIDTH).toBe(1080)
+    })
+
+    it('PORTRAIT_HEIGHT is 1920', () => {
+      expect(PORTRAIT_HEIGHT).toBe(1920)
+    })
+  })
+
+  describe('DEFAULT_VERTICAL_LAYOUT', () => {
+    it('has music on v-top, book v-middle, movie v-bottom', () => {
+      expect(DEFAULT_VERTICAL_LAYOUT).toEqual({
+        'v-top': 'music',
+        'v-middle': 'book',
+        'v-bottom': 'movie',
+      } satisfies VerticalLayoutConfig)
+    })
+  })
+
+  describe('VERTICAL_SLOT_LABELS', () => {
+    it('has Japanese labels for vertical slot positions', () => {
+      expect(VERTICAL_SLOT_LABELS['v-top']).toBe('上')
+      expect(VERTICAL_SLOT_LABELS['v-middle']).toBe('中')
+      expect(VERTICAL_SLOT_LABELS['v-bottom']).toBe('下')
+    })
+  })
+
+  describe('VERTICAL_SLOT_STYLES', () => {
+    it('all vertical slots span full width', () => {
+      for (const slot of VERTICAL_SLOT_POSITIONS) {
+        expect(VERTICAL_SLOT_STYLES[slot].width).toBe(PORTRAIT_WIDTH)
+      }
+    })
+
+    it('v-top slot starts at 0', () => {
+      expect(VERTICAL_SLOT_STYLES['v-top'].top).toBe(0)
+    })
+
+    it('vertical slots cover the full portrait height', () => {
+      const totalHeight =
+        VERTICAL_SLOT_STYLES['v-top'].height +
+        SEP +
+        VERTICAL_SLOT_STYLES['v-middle'].height +
+        SEP +
+        VERTICAL_SLOT_STYLES['v-bottom'].height
+      expect(totalHeight).toBe(PORTRAIT_HEIGHT)
+    })
+
+    it('exports VerticalSlotPosition type correctly', () => {
+      const slot: VerticalSlotPosition = 'v-top'
+      expect(VERTICAL_SLOT_STYLES[slot]).toBeDefined()
     })
   })
 })

--- a/src/constants/image-layout.ts
+++ b/src/constants/image-layout.ts
@@ -1,12 +1,25 @@
 import type { MediaCategory } from '../types/common'
 import { PRIMARY_LIGHT, SECONDARY, ACCENT } from './image-colors'
 
+export type AspectRatio = 'landscape' | 'portrait'
+
 export type SlotPosition = 'top' | 'bottom-left' | 'bottom-right'
+export type VerticalSlotPosition = 'v-top' | 'v-middle' | 'v-bottom'
+export type AnySlotPosition = SlotPosition | VerticalSlotPosition
 export type LayoutConfig = Record<SlotPosition, MediaCategory>
+export type VerticalLayoutConfig = Record<VerticalSlotPosition, MediaCategory>
 
 export const IMAGE_SIZE = 1080
 export const HALF = IMAGE_SIZE / 2
 export const SEP = 2
+
+/** Portrait (9:16) dimensions */
+export const PORTRAIT_WIDTH = 1080
+export const PORTRAIT_HEIGHT = 1920
+/** Available height for slots after subtracting 2 separators */
+const V_AVAILABLE = PORTRAIT_HEIGHT - SEP * 2 // 1916
+const V_SLOT_BASE = Math.floor(V_AVAILABLE / 3) // 638
+const V_SLOT_REM = V_AVAILABLE - V_SLOT_BASE * 3 // 2
 
 export const CATEGORY_COLORS: Record<MediaCategory, string> = {
   book: PRIMARY_LIGHT,
@@ -29,10 +42,22 @@ export const DEFAULT_LAYOUT: LayoutConfig = {
   'bottom-right': 'movie',
 }
 
+export const DEFAULT_VERTICAL_LAYOUT: VerticalLayoutConfig = {
+  'v-top': 'music',
+  'v-middle': 'book',
+  'v-bottom': 'movie',
+}
+
 export const SLOT_LABELS: Record<SlotPosition, string> = {
   top: '上',
   'bottom-left': '左下',
   'bottom-right': '右下',
+}
+
+export const VERTICAL_SLOT_LABELS: Record<VerticalSlotPosition, string> = {
+  'v-top': '上',
+  'v-middle': '中',
+  'v-bottom': '下',
 }
 
 // Re-export from category.ts (single source of truth)
@@ -78,8 +103,49 @@ export const SLOT_STYLES: Record<SlotPosition, SlotStyle> = {
   },
 }
 
+// Distribute remaining pixels to the first slot(s)
+const V_H1 = V_SLOT_BASE + Math.min(V_SLOT_REM, 1) // 639
+const V_H2 = V_SLOT_BASE + (V_SLOT_REM > 1 ? 1 : 0) // 639
+const V_H3 = V_AVAILABLE - V_H1 - V_H2 // 638
+
+export const VERTICAL_SLOT_STYLES: Record<VerticalSlotPosition, SlotStyle> = {
+  'v-top': {
+    top: 0,
+    left: 0,
+    width: PORTRAIT_WIDTH,
+    height: V_H1,
+    titleSize: 44,
+    subtitleSize: 20,
+    padding: '36px 48px',
+  },
+  'v-middle': {
+    top: V_H1 + SEP,
+    left: 0,
+    width: PORTRAIT_WIDTH,
+    height: V_H2,
+    titleSize: 44,
+    subtitleSize: 20,
+    padding: '36px 48px',
+  },
+  'v-bottom': {
+    top: V_H1 + SEP + V_H2 + SEP,
+    left: 0,
+    width: PORTRAIT_WIDTH,
+    height: V_H3,
+    titleSize: 44,
+    subtitleSize: 20,
+    padding: '36px 48px',
+  },
+}
+
 export const SLOT_POSITIONS: SlotPosition[] = [
   'top',
   'bottom-left',
   'bottom-right',
+]
+
+export const VERTICAL_SLOT_POSITIONS: VerticalSlotPosition[] = [
+  'v-top',
+  'v-middle',
+  'v-bottom',
 ]

--- a/src/hooks/useImageCapture.ts
+++ b/src/hooks/useImageCapture.ts
@@ -6,15 +6,23 @@ import {
   formatDate,
 } from '../utils/image-helpers'
 
-const IMAGE_SIZE = 1080
+export type ImageDimensions = {
+  width: number
+  height: number
+}
 
-export function useImageCapture(theme: string) {
+export function useImageCapture(
+  theme: string,
+  dimensions: ImageDimensions = { width: 1080, height: 1080 },
+) {
   const captureRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [successOpen, setSuccessOpen] = useState(false)
   const [scale, setScale] = useState(0.5)
+
+  const { width, height } = dimensions
 
   useEffect(() => {
     const container = containerRef.current
@@ -23,7 +31,7 @@ export function useImageCapture(theme: string) {
     const updateScale = () => {
       const containerWidth = container.clientWidth
       const newScale =
-        Math.round(Math.min(containerWidth / IMAGE_SIZE, 0.5) * 1000) / 1000
+        Math.round(Math.min(containerWidth / width, 0.5) * 1000) / 1000
       setScale(newScale)
     }
 
@@ -32,7 +40,7 @@ export function useImageCapture(theme: string) {
     const observer = new ResizeObserver(updateScale)
     observer.observe(container)
     return () => observer.disconnect()
-  }, [])
+  }, [width])
 
   const handleDownload = useCallback(async () => {
     if (!captureRef.current) return
@@ -40,7 +48,10 @@ export function useImageCapture(theme: string) {
     setIsGenerating(true)
     setError(null)
     try {
-      const blob = await generateImageBlob(captureRef.current)
+      const blob = await generateImageBlob(captureRef.current, {
+        width,
+        height,
+      })
       const dataUrl = URL.createObjectURL(blob)
 
       const date = formatDate()
@@ -57,7 +68,7 @@ export function useImageCapture(theme: string) {
     } finally {
       setIsGenerating(false)
     }
-  }, [theme])
+  }, [theme, width, height])
 
   return {
     captureRef,
@@ -69,6 +80,7 @@ export function useImageCapture(theme: string) {
     setSuccessOpen,
     scale,
     handleDownload,
-    IMAGE_SIZE,
+    width,
+    height,
   }
 }

--- a/src/hooks/useLayoutSwap.ts
+++ b/src/hooks/useLayoutSwap.ts
@@ -1,7 +1,17 @@
 import { useState, useCallback } from 'react'
 import type { MediaCategory } from '../types/common'
-import type { LayoutConfig, SlotPosition } from '../constants/image-layout'
-import { DEFAULT_LAYOUT, SLOT_POSITIONS } from '../constants/image-layout'
+import type {
+  LayoutConfig,
+  SlotPosition,
+  VerticalLayoutConfig,
+  VerticalSlotPosition,
+} from '../constants/image-layout'
+import {
+  DEFAULT_LAYOUT,
+  DEFAULT_VERTICAL_LAYOUT,
+  SLOT_POSITIONS,
+  VERTICAL_SLOT_POSITIONS,
+} from '../constants/image-layout'
 
 export function useLayoutSwap() {
   const [layout, setLayout] = useState<LayoutConfig>(DEFAULT_LAYOUT)
@@ -10,6 +20,32 @@ export function useLayoutSwap() {
     (slot: SlotPosition, newCategory: MediaCategory) => {
       setLayout((prev) => {
         const otherSlot = SLOT_POSITIONS.find((s) => prev[s] === newCategory)
+        if (!otherSlot || otherSlot === slot) return prev
+
+        return {
+          ...prev,
+          [slot]: newCategory,
+          [otherSlot]: prev[slot],
+        }
+      })
+    },
+    [],
+  )
+
+  return { layout, handleLayoutChange }
+}
+
+export function useVerticalLayoutSwap() {
+  const [layout, setLayout] = useState<VerticalLayoutConfig>(
+    DEFAULT_VERTICAL_LAYOUT,
+  )
+
+  const handleLayoutChange = useCallback(
+    (slot: VerticalSlotPosition, newCategory: MediaCategory) => {
+      setLayout((prev) => {
+        const otherSlot = VERTICAL_SLOT_POSITIONS.find(
+          (s) => prev[s] === newCategory,
+        )
         if (!otherSlot || otherSlot === slot) return prev
 
         return {

--- a/src/utils/image-helpers.test.ts
+++ b/src/utils/image-helpers.test.ts
@@ -65,6 +65,46 @@ describe('generateImageBlob', () => {
     await expect(generateImageBlob(el)).rejects.toThrow('canvas error')
   })
 
+  it('passes custom size to html2canvas', async () => {
+    const fakeBlob = new Blob(['fake'], { type: 'image/png' })
+    const fakeCanvas = document.createElement('canvas')
+    vi.spyOn(fakeCanvas, 'toBlob').mockImplementation((cb: BlobCallback) => {
+      cb(fakeBlob)
+    })
+    vi.mocked(html2canvas).mockResolvedValue(fakeCanvas)
+
+    const el = document.createElement('div')
+    await generateImageBlob(el, { width: 1080, height: 1920 })
+
+    expect(html2canvas).toHaveBeenCalledWith(
+      el,
+      expect.objectContaining({
+        width: 1080,
+        height: 1920,
+      }),
+    )
+  })
+
+  it('defaults to 1080x1080 when no size given', async () => {
+    const fakeBlob = new Blob(['fake'], { type: 'image/png' })
+    const fakeCanvas = document.createElement('canvas')
+    vi.spyOn(fakeCanvas, 'toBlob').mockImplementation((cb: BlobCallback) => {
+      cb(fakeBlob)
+    })
+    vi.mocked(html2canvas).mockResolvedValue(fakeCanvas)
+
+    const el = document.createElement('div')
+    await generateImageBlob(el)
+
+    expect(html2canvas).toHaveBeenCalledWith(
+      el,
+      expect.objectContaining({
+        width: 1080,
+        height: 1080,
+      }),
+    )
+  })
+
   it('throws when canvas produces empty data', async () => {
     const fakeCanvas = document.createElement('canvas')
     fakeCanvas.width = 0

--- a/src/utils/image-helpers.ts
+++ b/src/utils/image-helpers.ts
@@ -1,10 +1,21 @@
 import html2canvas from 'html2canvas'
 import { MESSAGES } from '../constants/messages'
 
-const IMAGE_SIZE = 1080
+const DEFAULT_SIZE = 1080
 const CANVAS_BG = '#111827'
 
-export async function generateImageBlob(element: HTMLElement): Promise<Blob> {
+export type ImageSize = {
+  width: number
+  height: number
+}
+
+export async function generateImageBlob(
+  element: HTMLElement,
+  size?: ImageSize,
+): Promise<Blob> {
+  const w = size?.width ?? DEFAULT_SIZE
+  const h = size?.height ?? DEFAULT_SIZE
+
   // Temporarily reset CSS transform so html2canvas captures at full size
   const origTransform = element.style.transform
   const origTransformOrigin = element.style.transformOrigin
@@ -13,8 +24,8 @@ export async function generateImageBlob(element: HTMLElement): Promise<Blob> {
 
   try {
     const canvas = await html2canvas(element, {
-      width: IMAGE_SIZE,
-      height: IMAGE_SIZE,
+      width: w,
+      height: h,
       scale: 1,
       useCORS: true,
       allowTaint: false,


### PR DESCRIPTION
## 概要

シェア画像の生成時に、縦長（9:16）のテンプレートを選択できるようにしました。

Closes #264

## 変更内容

### 新機能
- **アスペクト比セレクター**: 「横長 1:1」「縦長 9:16」を切り替えるトグルUIを追加
- **縦長テンプレート**: 1080x1920（9:16）の縦長レイアウトを実装。3作品を縦に並べる構成
- **縦長用レイアウトセレクター**: 上/中/下 のスロットにカテゴリを自由に配置可能

### 変更ファイル（12ファイル）

| ファイル | 変更内容 |
|---|---|
| `src/constants/image-layout.ts` | `AspectRatio`, `VerticalSlotPosition` 型、縦長定数・スロットスタイル追加 |
| `src/components/AspectRatioSelector.tsx` | **新規** - 横長/縦長の切り替えトグルUI |
| `src/components/Top3Image.tsx` | アスペクト比状態管理、縦長/横長レイアウト切り替え |
| `src/components/ImageSlot.tsx` | 縦長スロット位置（`v-top`, `v-middle`, `v-bottom`）対応 |
| `src/components/LayoutSelector.tsx` | `VerticalLayoutSelector` を追加 |
| `src/hooks/useImageCapture.ts` | 可変 width/height 対応 |
| `src/hooks/useLayoutSwap.ts` | `useVerticalLayoutSwap` を追加 |
| `src/utils/image-helpers.ts` | `generateImageBlob` を可変サイズ対応 |

## 要件チェック

- [x] シェア画像生成時にレイアウトを選択できるUI（横長 / 縦長）を追加
- [x] 9:16（1080x1920）の縦長テンプレートを実装
- [x] 縦長レイアウトでは3作品を縦に並べる構成にする
- [x] テーマ名・作品タイトルが見切れないよう調整
- [x] 既存の横長レイアウトはデフォルトとして維持

## テスト

- 全72ファイル / 649テスト通過
- 新規テスト: AspectRatioSelector（4件）、Top3Image 縦長モード（8件）、image-helpers サイズ指定（2件）、image-layout 縦長定数（8件）
- lint / format クリーン