### PR TITLE
feat: 画像プロキシにサーバーサイドLRUキャッシュを追加 (#277)

### DIFF
--- a/src/server/image-proxy-cache.test.ts
+++ b/src/server/image-proxy-cache.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createImageProxyCache } from './image-proxy-cache.ts'
+
+describe('ImageProxyCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stores and retrieves a cached image', () => {
+    const cache = createImageProxyCache()
+    const data = new Uint8Array([1, 2, 3])
+    cache.set('https://example.com/img.jpg', data, 'image/jpeg')
+
+    const result = cache.get('https://example.com/img.jpg')
+    expect(result).toBeDefined()
+    expect(result!.data).toEqual(data)
+    expect(result!.contentType).toBe('image/jpeg')
+  })
+
+  it('returns undefined for cache miss', () => {
+    const cache = createImageProxyCache()
+    expect(cache.get('https://example.com/missing.jpg')).toBeUndefined()
+  })
+
+  it('expires entries after TTL', () => {
+    const cache = createImageProxyCache({ ttlMs: 1000 })
+    const data = new Uint8Array([1, 2, 3])
+    cache.set('https://example.com/img.jpg', data, 'image/jpeg')
+
+    // Before expiration
+    vi.advanceTimersByTime(999)
+    expect(cache.get('https://example.com/img.jpg')).toBeDefined()
+
+    // After expiration
+    vi.advanceTimersByTime(2)
+    expect(cache.get('https://example.com/img.jpg')).toBeUndefined()
+  })
+
+  it('evicts oldest entry when maxEntries is reached', () => {
+    const cache = createImageProxyCache({ maxEntries: 2 })
+    const data = new Uint8Array([1])
+
+    cache.set('url1', data, 'image/png')
+    cache.set('url2', data, 'image/png')
+    cache.set('url3', data, 'image/png') // should evict url1
+
+    expect(cache.get('url1')).toBeUndefined()
+    expect(cache.get('url2')).toBeDefined()
+    expect(cache.get('url3')).toBeDefined()
+    expect(cache.size()).toBe(2)
+  })
+
+  it('evicts entries when maxTotalBytes is exceeded', () => {
+    const cache = createImageProxyCache({ maxTotalBytes: 10, maxEntries: 100 })
+
+    cache.set('url1', new Uint8Array(5), 'image/png')
+    cache.set('url2', new Uint8Array(5), 'image/png')
+    expect(cache.size()).toBe(2)
+    expect(cache.totalBytes()).toBe(10)
+
+    // Adding 6 bytes: 5+5+6=16 > 10, so url1 and url2 both get evicted
+    cache.set('url3', new Uint8Array(6), 'image/png')
+    expect(cache.get('url1')).toBeUndefined()
+    expect(cache.get('url2')).toBeUndefined()
+    expect(cache.size()).toBe(1)
+    expect(cache.totalBytes()).toBe(6)
+  })
+
+  it('skips caching entries larger than maxTotalBytes', () => {
+    const cache = createImageProxyCache({ maxTotalBytes: 10 })
+    cache.set('url1', new Uint8Array(11), 'image/png')
+    expect(cache.size()).toBe(0)
+    expect(cache.totalBytes()).toBe(0)
+  })
+
+  it('updates existing entry with same URL', () => {
+    const cache = createImageProxyCache()
+    cache.set('url1', new Uint8Array([1, 2, 3]), 'image/jpeg')
+    cache.set('url1', new Uint8Array([4, 5]), 'image/png')
+
+    expect(cache.size()).toBe(1)
+    const result = cache.get('url1')
+    expect(result!.data).toEqual(new Uint8Array([4, 5]))
+    expect(result!.contentType).toBe('image/png')
+  })
+
+  it('LRU: accessing an entry moves it to the end (prevents eviction)', () => {
+    const cache = createImageProxyCache({ maxEntries: 2 })
+    const data = new Uint8Array([1])
+
+    cache.set('url1', data, 'image/png')
+    cache.set('url2', data, 'image/png')
+
+    // Access url1 to make it recent
+    cache.get('url1')
+
+    // Adding url3 should evict url2 (oldest), not url1
+    cache.set('url3', data, 'image/png')
+    expect(cache.get('url1')).toBeDefined()
+    expect(cache.get('url2')).toBeUndefined()
+    expect(cache.get('url3')).toBeDefined()
+  })
+
+  it('tracks totalBytes correctly through set/evict/clear', () => {
+    const cache = createImageProxyCache({ maxEntries: 100 })
+    cache.set('url1', new Uint8Array(100), 'image/png')
+    cache.set('url2', new Uint8Array(200), 'image/png')
+    expect(cache.totalBytes()).toBe(300)
+
+    cache.clear()
+    expect(cache.totalBytes()).toBe(0)
+    expect(cache.size()).toBe(0)
+  })
+
+  it('decrements totalBytes when expired entry is accessed', () => {
+    const cache = createImageProxyCache({ ttlMs: 1000 })
+    cache.set('url1', new Uint8Array(100), 'image/png')
+    expect(cache.totalBytes()).toBe(100)
+
+    vi.advanceTimersByTime(1001)
+    cache.get('url1') // triggers eviction of expired entry
+    expect(cache.totalBytes()).toBe(0)
+  })
+})

--- a/src/server/image-proxy-cache.ts
+++ b/src/server/image-proxy-cache.ts
@@ -1,0 +1,106 @@
+export type CachedImage = {
+  data: Uint8Array
+  contentType: string
+  expiresAt: number
+}
+
+export type ImageProxyCacheOptions = {
+  /** Cache TTL in milliseconds (default: 24 hours) */
+  ttlMs?: number
+  /** Maximum number of entries (default: 500) */
+  maxEntries?: number
+  /** Maximum total cache size in bytes (default: 100MB) */
+  maxTotalBytes?: number
+}
+
+export type ImageProxyCache = {
+  get: (url: string) => CachedImage | undefined
+  set: (url: string, data: Uint8Array, contentType: string) => void
+  size: () => number
+  totalBytes: () => number
+  clear: () => void
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+const DEFAULT_MAX_ENTRIES = 500
+const DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024 // 100MB
+
+export function createImageProxyCache(
+  options?: ImageProxyCacheOptions,
+): ImageProxyCache {
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS
+  const maxEntries = options?.maxEntries ?? DEFAULT_MAX_ENTRIES
+  const maxTotalBytes = options?.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES
+
+  const store = new Map<string, CachedImage>()
+  let currentTotalBytes = 0
+
+  function evictOldest(): void {
+    const oldest = store.keys().next().value
+    if (oldest !== undefined) {
+      const entry = store.get(oldest)
+      if (entry) {
+        currentTotalBytes -= entry.data.byteLength
+      }
+      store.delete(oldest)
+    }
+  }
+
+  return {
+    get(url: string): CachedImage | undefined {
+      const entry = store.get(url)
+      if (!entry) return undefined
+      if (Date.now() > entry.expiresAt) {
+        currentTotalBytes -= entry.data.byteLength
+        store.delete(url)
+        return undefined
+      }
+      // LRU: move to end by re-inserting
+      store.delete(url)
+      store.set(url, entry)
+      return entry
+    },
+
+    set(url: string, data: Uint8Array, contentType: string): void {
+      // Don't cache entries larger than the total limit
+      if (data.byteLength > maxTotalBytes) return
+
+      // Remove existing entry if present
+      const existing = store.get(url)
+      if (existing) {
+        currentTotalBytes -= existing.data.byteLength
+        store.delete(url)
+      }
+
+      // Evict until we have space
+      while (
+        store.size >= maxEntries ||
+        currentTotalBytes + data.byteLength > maxTotalBytes
+      ) {
+        if (store.size === 0) break
+        evictOldest()
+      }
+
+      const entry: CachedImage = {
+        data,
+        contentType,
+        expiresAt: Date.now() + ttlMs,
+      }
+      store.set(url, entry)
+      currentTotalBytes += data.byteLength
+    },
+
+    size(): number {
+      return store.size
+    },
+
+    totalBytes(): number {
+      return currentTotalBytes
+    },
+
+    clear(): void {
+      store.clear()
+      currentTotalBytes = 0
+    },
+  }
+}

--- a/src/server/routes/image-proxy.test.ts
+++ b/src/server/routes/image-proxy.test.ts
@@ -1,11 +1,18 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { imageProxyApp, ALLOWED_HOSTS } from './image-proxy.ts'
+import { createImageProxyApp, ALLOWED_HOSTS } from './image-proxy.ts'
+import { createImageProxyCache } from '../image-proxy-cache.ts'
 
 type ErrorResponse = { ok: false; error: { kind: string; message: string } }
 
 // Mock global fetch
 const originalFetch = globalThis.fetch
+
+function makeApp() {
+  const cache = createImageProxyCache()
+  const app = createImageProxyApp(cache)
+  return { app, cache }
+}
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -18,7 +25,8 @@ afterEach(() => {
 describe('image-proxy route', () => {
   describe('GET /proxy', () => {
     it('returns 400 when url query parameter is missing', async () => {
-      const res = await imageProxyApp.request('/proxy')
+      const { app } = makeApp()
+      const res = await app.request('/proxy')
       expect(res.status).toBe(400)
       const json = (await res.json()) as ErrorResponse
       expect(json.ok).toBe(false)
@@ -26,14 +34,16 @@ describe('image-proxy route', () => {
     })
 
     it('returns 400 when url is not a valid URL', async () => {
-      const res = await imageProxyApp.request('/proxy?url=not-a-url')
+      const { app } = makeApp()
+      const res = await app.request('/proxy?url=not-a-url')
       expect(res.status).toBe(400)
       const json = (await res.json()) as ErrorResponse
       expect(json.ok).toBe(false)
     })
 
     it('returns 403 when host is not in allowlist', async () => {
-      const res = await imageProxyApp.request(
+      const { app } = makeApp()
+      const res = await app.request(
         '/proxy?url=https://evil.example.com/image.jpg',
       )
       expect(res.status).toBe(403)
@@ -43,6 +53,7 @@ describe('image-proxy route', () => {
     })
 
     it('proxies image from allowed Google Books host', async () => {
+      const { app } = makeApp()
       const imageData = new Uint8Array([137, 80, 78, 71]) // PNG magic bytes
       globalThis.fetch = vi.fn().mockResolvedValue(
         new Response(imageData, {
@@ -55,9 +66,7 @@ describe('image-proxy route', () => {
       )
 
       const url = 'https://books.google.com/books/content?id=abc&img=1'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(200)
       expect(res.headers.get('Content-Type')).toBe('image/jpeg')
@@ -66,6 +75,7 @@ describe('image-proxy route', () => {
     })
 
     it('proxies image from allowed Last.fm CDN host', async () => {
+      const { app } = makeApp()
       globalThis.fetch = vi.fn().mockResolvedValue(
         new Response(new Uint8Array([0xff, 0xd8]), {
           status: 200,
@@ -74,9 +84,7 @@ describe('image-proxy route', () => {
       )
 
       const url = 'https://lastfm.freetls.fastly.net/image/abc123'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(200)
       expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledWith(
@@ -86,6 +94,7 @@ describe('image-proxy route', () => {
     })
 
     it('proxies image from allowed TMDB host', async () => {
+      const { app } = makeApp()
       globalThis.fetch = vi.fn().mockResolvedValue(
         new Response(new Uint8Array([0xff, 0xd8]), {
           status: 200,
@@ -94,22 +103,19 @@ describe('image-proxy route', () => {
       )
 
       const url = 'https://image.tmdb.org/t/p/w300/poster.jpg'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(200)
     })
 
     it('returns 502 when upstream returns non-2xx status', async () => {
+      const { app } = makeApp()
       globalThis.fetch = vi
         .fn()
         .mockResolvedValue(new Response('Not Found', { status: 404 }))
 
       const url = 'https://lastfm.freetls.fastly.net/image/missing'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(502)
       const json = (await res.json()) as ErrorResponse
@@ -117,24 +123,25 @@ describe('image-proxy route', () => {
     })
 
     it('returns 502 when upstream fetch fails', async () => {
+      const { app } = makeApp()
       globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'))
 
       const url = 'https://lastfm.freetls.fastly.net/image/abc'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(502)
     })
 
     it('returns 403 for non-https URLs', async () => {
-      const res = await imageProxyApp.request(
+      const { app } = makeApp()
+      const res = await app.request(
         '/proxy?url=http://lastfm.freetls.fastly.net/image/abc',
       )
       expect(res.status).toBe(403)
     })
 
     it('returns 400 for non-image content-type from upstream', async () => {
+      const { app } = makeApp()
       globalThis.fetch = vi.fn().mockResolvedValue(
         new Response('<html></html>', {
           status: 200,
@@ -143,15 +150,14 @@ describe('image-proxy route', () => {
       )
 
       const url = 'https://lastfm.freetls.fastly.net/image/abc'
-      const res = await imageProxyApp.request(
-        `/proxy?url=${encodeURIComponent(url)}`,
-      )
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
       expect(res.status).toBe(400)
     })
   })
 
   it('returns 413 when Content-Length exceeds the size limit', async () => {
+    const { app } = makeApp()
     const overSizeBytes = 11 * 1024 * 1024 // 11MB
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response('too large', {
@@ -164,9 +170,7 @@ describe('image-proxy route', () => {
     )
 
     const url = 'https://books.google.com/books/content?id=abc&img=1'
-    const res = await imageProxyApp.request(
-      `/proxy?url=${encodeURIComponent(url)}`,
-    )
+    const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
     expect(res.status).toBe(413)
     const json = (await res.json()) as ErrorResponse
@@ -175,6 +179,7 @@ describe('image-proxy route', () => {
   })
 
   it('allows responses within the size limit', async () => {
+    const { app } = makeApp()
     const imageData = new Uint8Array(1024) // 1KB
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(imageData, {
@@ -187,15 +192,13 @@ describe('image-proxy route', () => {
     )
 
     const url = 'https://books.google.com/books/content?id=abc&img=1'
-    const res = await imageProxyApp.request(
-      `/proxy?url=${encodeURIComponent(url)}`,
-    )
+    const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
     expect(res.status).toBe(200)
   })
 
   it('returns 413 when streamed body exceeds the size limit without Content-Length', async () => {
-    // Create a ReadableStream that produces chunks exceeding 10MB
+    const { app } = makeApp()
     const chunkSize = 1024 * 1024 // 1MB per chunk
     let chunksSent = 0
     const stream = new ReadableStream({
@@ -214,15 +217,12 @@ describe('image-proxy route', () => {
         status: 200,
         headers: {
           'Content-Type': 'image/jpeg',
-          // No Content-Length header
         },
       }),
     )
 
     const url = 'https://books.google.com/books/content?id=abc&img=1'
-    const res = await imageProxyApp.request(
-      `/proxy?url=${encodeURIComponent(url)}`,
-    )
+    const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
     expect(res.status).toBe(413)
     const json = (await res.json()) as ErrorResponse
@@ -231,6 +231,7 @@ describe('image-proxy route', () => {
   })
 
   it('streams responses without Content-Length within the size limit', async () => {
+    const { app } = makeApp()
     const chunkSize = 1024
     let chunksSent = 0
     const stream = new ReadableStream({
@@ -254,13 +255,115 @@ describe('image-proxy route', () => {
     )
 
     const url = 'https://books.google.com/books/content?id=abc&img=1'
-    const res = await imageProxyApp.request(
-      `/proxy?url=${encodeURIComponent(url)}`,
-    )
+    const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
 
     expect(res.status).toBe(200)
     const body = await res.arrayBuffer()
     expect(body.byteLength).toBe(3 * 1024)
+  })
+
+  describe('server-side cache', () => {
+    it('returns X-Cache: MISS on first request', async () => {
+      const { app } = makeApp()
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { 'Content-Type': 'image/jpeg' },
+        }),
+      )
+
+      const url = 'https://books.google.com/books/content?id=abc&img=1'
+      const res = await app.request(`/proxy?url=${encodeURIComponent(url)}`)
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('X-Cache')).toBe('MISS')
+    })
+
+    it('returns X-Cache: HIT on second request and does not call fetch again', async () => {
+      const { app } = makeApp()
+      const imageData = new Uint8Array([1, 2, 3])
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(imageData, {
+          status: 200,
+          headers: { 'Content-Type': 'image/jpeg' },
+        }),
+      )
+      globalThis.fetch = mockFetch
+
+      const url = 'https://books.google.com/books/content?id=abc&img=1'
+      const encodedUrl = `/proxy?url=${encodeURIComponent(url)}`
+
+      // First request - MISS
+      const res1 = await app.request(encodedUrl)
+      expect(res1.status).toBe(200)
+      expect(res1.headers.get('X-Cache')).toBe('MISS')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Second request - HIT (fetch should not be called again)
+      const res2 = await app.request(encodedUrl)
+      expect(res2.status).toBe(200)
+      expect(res2.headers.get('X-Cache')).toBe('HIT')
+      expect(res2.headers.get('Content-Type')).toBe('image/jpeg')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const body = new Uint8Array(await res2.arrayBuffer())
+      expect(body).toEqual(imageData)
+    })
+
+    it('caches different URLs separately', async () => {
+      const { app } = makeApp()
+      let callCount = 0
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callCount++
+        return Promise.resolve(
+          new Response(new Uint8Array([callCount]), {
+            status: 200,
+            headers: { 'Content-Type': 'image/png' },
+          }),
+        )
+      })
+
+      const url1 = 'https://books.google.com/img1'
+      const url2 = 'https://books.google.com/img2'
+
+      await app.request(`/proxy?url=${encodeURIComponent(url1)}`)
+      await app.request(`/proxy?url=${encodeURIComponent(url2)}`)
+
+      expect(callCount).toBe(2)
+
+      // Both should be cached
+      const res1 = await app.request(`/proxy?url=${encodeURIComponent(url1)}`)
+      const res2 = await app.request(`/proxy?url=${encodeURIComponent(url2)}`)
+      expect(res1.headers.get('X-Cache')).toBe('HIT')
+      expect(res2.headers.get('X-Cache')).toBe('HIT')
+      expect(callCount).toBe(2) // no additional fetches
+    })
+
+    it('does not cache error responses', async () => {
+      const { app } = makeApp()
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+        .mockResolvedValueOnce(
+          new Response(new Uint8Array([1]), {
+            status: 200,
+            headers: { 'Content-Type': 'image/jpeg' },
+          }),
+        )
+      globalThis.fetch = mockFetch
+
+      const url = 'https://books.google.com/img'
+      const encodedUrl = `/proxy?url=${encodeURIComponent(url)}`
+
+      // First request fails
+      const res1 = await app.request(encodedUrl)
+      expect(res1.status).toBe(502)
+
+      // Second request should fetch again (not cached)
+      const res2 = await app.request(encodedUrl)
+      expect(res2.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('ALLOWED_HOSTS', () => {

--- a/src/server/routes/image-proxy.ts
+++ b/src/server/routes/image-proxy.ts
@@ -1,4 +1,8 @@
 import { Hono } from 'hono'
+import {
+  createImageProxyCache,
+  type ImageProxyCache,
+} from '../image-proxy-cache.ts'
 
 export const ALLOWED_HOSTS = [
   'books.google.com',
@@ -62,134 +66,162 @@ async function readWithSizeLimit(
   return result
 }
 
-export const imageProxyApp = new Hono()
+const defaultCache = createImageProxyCache()
 
-imageProxyApp.get('/proxy', async (c) => {
-  const urlParam = c.req.query('url')
+export function createImageProxyApp(
+  cache: ImageProxyCache = defaultCache,
+): Hono {
+  const app = new Hono()
 
-  if (!urlParam) {
-    return c.json(
-      {
-        ok: false,
-        error: { kind: 'unknown', message: 'urlパラメータが必要です' },
-      },
-      400,
-    )
-  }
+  app.get('/proxy', async (c) => {
+    const urlParam = c.req.query('url')
 
-  let parsed: URL
-  try {
-    parsed = new URL(urlParam)
-  } catch {
-    return c.json(
-      { ok: false, error: { kind: 'unknown', message: '無効なURLです' } },
-      400,
-    )
-  }
-
-  if (parsed.protocol !== 'https:') {
-    return c.json(
-      {
-        ok: false,
-        error: { kind: 'unknown', message: '許可されていないホストです' },
-      },
-      403,
-    )
-  }
-
-  if (!isAllowedHost(parsed.hostname)) {
-    return c.json(
-      {
-        ok: false,
-        error: { kind: 'unknown', message: '許可されていないホストです' },
-      },
-      403,
-    )
-  }
-
-  try {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS)
-
-    const upstream = await fetch(urlParam, {
-      signal: controller.signal,
-    })
-
-    clearTimeout(timeout)
-
-    if (!upstream.ok) {
+    if (!urlParam) {
       return c.json(
         {
           ok: false,
-          error: {
-            kind: 'unknown',
-            message: `上流サーバーがエラーを返しました (status: ${upstream.status})`,
-          },
-        },
-        502,
-      )
-    }
-
-    const contentType = upstream.headers.get('Content-Type')
-    if (!isImageContentType(contentType)) {
-      return c.json(
-        {
-          ok: false,
-          error: {
-            kind: 'unknown',
-            message: '画像以外のコンテンツタイプです',
-          },
+          error: { kind: 'unknown', message: 'urlパラメータが必要です' },
         },
         400,
       )
     }
 
-    // Content-Length が明示されていて上限超過なら即拒否
-    const contentLength = upstream.headers.get('Content-Length')
-    if (contentLength && Number(contentLength) > MAX_RESPONSE_SIZE) {
+    let parsed: URL
+    try {
+      parsed = new URL(urlParam)
+    } catch {
       return c.json(
-        {
-          ok: false,
-          error: {
-            kind: 'unknown',
-            message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
-          },
-        },
-        413,
+        { ok: false, error: { kind: 'unknown', message: '無効なURLです' } },
+        400,
       )
     }
 
-    // ストリーミング読み込みでサイズ制限を強制
-    const body = await readWithSizeLimit(upstream, MAX_RESPONSE_SIZE)
-    if (body === null) {
+    if (parsed.protocol !== 'https:') {
       return c.json(
         {
           ok: false,
-          error: {
-            kind: 'unknown',
-            message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
-          },
+          error: { kind: 'unknown', message: '許可されていないホストです' },
         },
-        413,
+        403,
       )
     }
 
-    return new Response(body, {
-      status: 200,
-      headers: {
-        'Content-Type': contentType!,
-        'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
-        'Access-Control-Allow-Origin': '*',
-      },
-    })
-  } catch (err) {
-    console.error('[image-proxy] fetch error:', err)
-    return c.json(
-      {
-        ok: false,
-        error: { kind: 'unknown', message: '画像の取得に失敗しました' },
-      },
-      502,
-    )
-  }
-})
+    if (!isAllowedHost(parsed.hostname)) {
+      return c.json(
+        {
+          ok: false,
+          error: { kind: 'unknown', message: '許可されていないホストです' },
+        },
+        403,
+      )
+    }
+
+    // Check server-side cache
+    const cached = cache.get(urlParam)
+    if (cached) {
+      return new Response(cached.data, {
+        status: 200,
+        headers: {
+          'Content-Type': cached.contentType,
+          'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
+          'Access-Control-Allow-Origin': '*',
+          'X-Cache': 'HIT',
+        },
+      })
+    }
+
+    try {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS)
+
+      const upstream = await fetch(urlParam, {
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeout)
+
+      if (!upstream.ok) {
+        return c.json(
+          {
+            ok: false,
+            error: {
+              kind: 'unknown',
+              message: `上流サーバーがエラーを返しました (status: ${upstream.status})`,
+            },
+          },
+          502,
+        )
+      }
+
+      const contentType = upstream.headers.get('Content-Type')
+      if (!isImageContentType(contentType)) {
+        return c.json(
+          {
+            ok: false,
+            error: {
+              kind: 'unknown',
+              message: '画像以外のコンテンツタイプです',
+            },
+          },
+          400,
+        )
+      }
+
+      // Content-Length が明示されていて上限超過なら即拒否
+      const contentLength = upstream.headers.get('Content-Length')
+      if (contentLength && Number(contentLength) > MAX_RESPONSE_SIZE) {
+        return c.json(
+          {
+            ok: false,
+            error: {
+              kind: 'unknown',
+              message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
+            },
+          },
+          413,
+        )
+      }
+
+      // ストリーミング読み込みでサイズ制限を強制
+      const body = await readWithSizeLimit(upstream, MAX_RESPONSE_SIZE)
+      if (body === null) {
+        return c.json(
+          {
+            ok: false,
+            error: {
+              kind: 'unknown',
+              message: `レスポンスサイズが上限（${MAX_RESPONSE_SIZE} bytes）を超えています`,
+            },
+          },
+          413,
+        )
+      }
+
+      // Store in server-side cache
+      cache.set(urlParam, body, contentType!)
+
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType!,
+          'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
+          'Access-Control-Allow-Origin': '*',
+          'X-Cache': 'MISS',
+        },
+      })
+    } catch (err) {
+      console.error('[image-proxy] fetch error:', err)
+      return c.json(
+        {
+          ok: false,
+          error: { kind: 'unknown', message: '画像の取得に失敗しました' },
+        },
+        502,
+      )
+    }
+  })
+
+  return app
+}
+
+export const imageProxyApp = createImageProxyApp()


### PR DESCRIPTION
## 概要

Closes #277

画像プロキシ (`/api/image/proxy`) にサーバーサイドのインメモリLRUキャッシュを追加しました。

## 変更内容

### 新規ファイル
- **`src/server/image-proxy-cache.ts`** - 画像プロキシ用キャッシュモジュール
  - LRU eviction（最も使用されていないエントリから削除）
  - TTL（デフォルト24時間で有効期限切れ）
  - エントリ数上限（デフォルト500）
  - 合計バイト数上限（デフォルト100MB）
- **`src/server/image-proxy-cache.test.ts`** - キャッシュ単体テスト（10件）

### 変更ファイル
- **`src/server/routes/image-proxy.ts`**
  - `createImageProxyApp(cache?)` ファクトリ関数に変更（DI対応）
  - キャッシュHIT時は上流fetchをスキップして即レスポンス
  - `X-Cache: HIT` / `X-Cache: MISS` ヘッダーで判別可能
- **`src/server/routes/image-proxy.test.ts`**
  - テストごとに独立したキャッシュインスタンスを使用
  - キャッシュ動作テスト4件追加（HIT/MISS、URL別キャッシュ、エラー非キャッシュ）

## テスト結果

全775テスト通過 ✅