### PR TITLE
fix: CORS_ORIGIN未設定時にエラーで起動を停止する (#278)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ LASTFM_API_KEY=
 
 # TMDb API
 TMDB_API_KEY=
+
+# CORS allowed origins (required, comma-separated)
+# Example: https://myapp.example.com or https://a.com,https://b.com
+CORS_ORIGIN=

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ export default defineConfig([
 - `npm install` で依存パッケージがインストール済みであること
 - `.env` ファイルに API キーが設定されていること
 
+#### 環境変数
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `CORS_ORIGIN` | **必須** | CORS 許可オリジン（カンマ区切りで複数指定可）。未設定の場合サーバーは起動しません。例: `https://myapp.example.com` |
+| `GOOGLE_BOOKS_API_KEY` | 推奨 | Google Books API キー |
+| `LASTFM_API_KEY` | 推奨 | Last.fm API キー |
+| `TMDB_API_KEY` | 推奨 | TMDb API キー |
+| `ADMIN_API_KEY` | 任意 | 管理用 API キー |
+| `SHARES_DATA_PATH` | 任意 | SQLite DB ファイルパス（デフォルト: `data/shares.db`） |
+| `PORT` | 任意 | サーバーポート（デフォルト: `8000`） |
+
 #### セットアップ手順
 
 1. セットアップスクリプトを実行します:

--- a/src/server/cors.test.ts
+++ b/src/server/cors.test.ts
@@ -31,30 +31,39 @@ describe('CORS middleware', () => {
     return mod.default
   }
 
-  it('returns CORS headers for /api/* with default origin (https://myno1s.exe.xyz:8000)', async () => {
-    const app = await getApp()
-    const req = new Request('http://localhost/api/books/search?q=test', {
-      headers: { Origin: 'https://myno1s.exe.xyz:8000' },
-    })
-    const res = await app.request(req)
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
-      'https://myno1s.exe.xyz:8000',
+  it('throws error when CORS_ORIGIN is not set', async () => {
+    delete process.env['CORS_ORIGIN']
+    await expect(getApp()).rejects.toThrow(
+      'CORS_ORIGIN environment variable is required',
     )
   })
 
-  it('handles preflight OPTIONS request with default origin', async () => {
+  it('returns CORS headers when CORS_ORIGIN is set', async () => {
+    process.env['CORS_ORIGIN'] = 'https://custom.example.com'
+    const app = await getApp()
+    const req = new Request('http://localhost/api/books/search?q=test', {
+      headers: { Origin: 'https://custom.example.com' },
+    })
+    const res = await app.request(req)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://custom.example.com',
+    )
+  })
+
+  it('handles preflight OPTIONS request', async () => {
+    process.env['CORS_ORIGIN'] = 'https://custom.example.com'
     const app = await getApp()
     const req = new Request('http://localhost/api/books/search', {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://myno1s.exe.xyz:8000',
+        Origin: 'https://custom.example.com',
         'Access-Control-Request-Method': 'GET',
       },
     })
     const res = await app.request(req)
     expect(res.status).toBe(204)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
-      'https://myno1s.exe.xyz:8000',
+      'https://custom.example.com',
     )
     expect(res.headers.get('Access-Control-Allow-Methods')).toBe(
       'GET,POST,DELETE',
@@ -62,11 +71,12 @@ describe('CORS middleware', () => {
   })
 
   it('allows POST in preflight for /api/shares', async () => {
+    process.env['CORS_ORIGIN'] = 'https://custom.example.com'
     const app = await getApp()
     const req = new Request('http://localhost/api/shares', {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://myno1s.exe.xyz:8000',
+        Origin: 'https://custom.example.com',
         'Access-Control-Request-Method': 'POST',
         'Access-Control-Request-Headers': 'content-type',
       },
@@ -77,24 +87,13 @@ describe('CORS middleware', () => {
   })
 
   it('does not return CORS headers for disallowed origin', async () => {
+    process.env['CORS_ORIGIN'] = 'https://allowed.example.com'
     const app = await getApp()
     const req = new Request('http://localhost/api/books/search?q=test', {
       headers: { Origin: 'https://evil.example.com' },
     })
     const res = await app.request(req)
     expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
-  })
-
-  it('uses CORS_ORIGIN env var when set', async () => {
-    process.env['CORS_ORIGIN'] = 'https://custom.example.com'
-    const app = await getApp()
-    const req = new Request('http://localhost/api/books/search?q=test', {
-      headers: { Origin: 'https://custom.example.com' },
-    })
-    const res = await app.request(req)
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
-      'https://custom.example.com',
-    )
   })
 
   it('supports multiple origins via comma-separated CORS_ORIGIN', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,9 +31,13 @@ if (!process.env['TMDB_API_KEY']) {
 
 const app = new Hono()
 
-const corsOrigins = process.env['CORS_ORIGIN']
-  ? process.env['CORS_ORIGIN'].split(',')
-  : ['https://myno1s.exe.xyz:8000']
+if (!process.env['CORS_ORIGIN']) {
+  throw new Error(
+    'CORS_ORIGIN environment variable is required. Set it to comma-separated allowed origins (e.g. CORS_ORIGIN=https://example.com)',
+  )
+}
+
+const corsOrigins = process.env['CORS_ORIGIN'].split(',')
 
 app.use(
   '/api/*',


### PR DESCRIPTION
- ハードコードされたデフォルトオリジン(https://myno1s.exe.xyz:8000)を削除
- CORS_ORIGIN環境変数が未設定の場合、明確なエラーメッセージで起動を停止
- .env.exampleにCORS_ORIGINの設定を追記
- READMEに環境変数一覧テーブルを追加
- テストを新しい挙動に合わせて更新