### PR TITLE
fix: loadMore無限ループによる429エラーを修正

### DIFF
--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -182,6 +182,63 @@ describe('useSearch', () => {
     expect(result.current.results[0].category).toBe('music')
   })
 
+  it('stops pagination when loadMore returns only duplicate items', async () => {
+    let callCount = 0
+    server.use(
+      http.get('/api/books/search', () => {
+        callCount++
+        // Every call returns the same 2 items
+        return HttpResponse.json({
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'b1',
+                category: 'book',
+                title: 'Book 1',
+                subtitle: 'A1',
+                thumbnailUrl: '',
+                externalUrl: '',
+              },
+              {
+                id: 'b2',
+                category: 'book',
+                title: 'Book 2',
+                subtitle: 'A2',
+                thumbnailUrl: '',
+                externalUrl: '',
+              },
+            ],
+            totalItems: 100,
+            startIndex: 0,
+          },
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useSearch('book', 'test'))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.results).toHaveLength(2)
+    expect(result.current.hasMore).toBe(true)
+
+    // loadMore returns the same items → all duplicates → should stop
+    const countBefore = callCount
+    result.current.loadMore()
+    await waitFor(() => {
+      // Wait for loadMore to actually fire (callCount increases)
+      expect(callCount).toBeGreaterThan(countBefore)
+    })
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.hasMore).toBe(false)
+    expect(result.current.results).toHaveLength(2)
+    // Should have only made 2 calls total (initial + 1 loadMore), not an infinite loop
+    expect(callCount).toBeLessThanOrEqual(3)
+  })
+
   it('uses API_ENDPOINTS for movie category', async () => {
     let requestedUrl = ''
     server.use(

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -21,9 +21,12 @@ export function useSearch(
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [hasMore, setHasMore] = useState(false)
-  const [startIndex, setStartIndex] = useState(0)
   const abortControllerRef = useRef<AbortController | null>(null)
   const isLoadingMoreRef = useRef(false)
+  // Track startIndex via ref to avoid stale closures in loadMore
+  const startIndexRef = useRef(0)
+  // Track last requested index to prevent duplicate requests
+  const lastRequestedIndexRef = useRef<number | null>(null)
 
   const fetchResults = useCallback(
     async (index: number, append: boolean) => {
@@ -83,9 +86,12 @@ export function useSearch(
         const { items, totalItems, startIndex: returnedIndex } = json.data
 
         if (append) {
+          // Use a ref-like container to extract uniqueCount from the state updater
+          const countRef = { value: 0 }
           setResults((prev) => {
             const existingIds = new Set(prev.map((r) => r.id))
             const unique = items.filter((item) => !existingIds.has(item.id))
+            countRef.value = unique.length
             if (import.meta.env.DEV && unique.length < items.length) {
               console.warn(
                 `[useSearch] Dropped ${items.length - unique.length} duplicate item(s) during pagination.`,
@@ -93,6 +99,19 @@ export function useSearch(
             }
             return [...prev, ...unique]
           })
+
+          // React 18 batches state updates, but the updater function runs synchronously
+          // within setResults, so countRef.value is available here.
+          if (countRef.value === 0 && items.length > 0) {
+            if (import.meta.env.DEV) {
+              console.warn(
+                `[useSearch] All ${items.length} item(s) were duplicates at index=${returnedIndex}. Stopping pagination.`,
+              )
+            }
+            setHasMore(false)
+            startIndexRef.current = returnedIndex + items.length
+            return
+          }
         } else {
           setResults(items)
         }
@@ -104,7 +123,7 @@ export function useSearch(
           )
         }
         setHasMore(items.length > 0 && moreAvailable)
-        setStartIndex(returnedIndex + items.length)
+        startIndexRef.current = returnedIndex + items.length
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') {
           return
@@ -121,7 +140,8 @@ export function useSearch(
   )
 
   useEffect(() => {
-    setStartIndex(0)
+    startIndexRef.current = 0
+    lastRequestedIndexRef.current = null
     setResults([])
     setHasMore(false)
     fetchResults(0, false)
@@ -137,9 +157,16 @@ export function useSearch(
     if (isLoadingMoreRef.current || isLoading || !hasMore) {
       return
     }
+    // Use ref to always get the latest startIndex (avoids stale closure)
+    const currentIndex = startIndexRef.current
+    // Guard against requesting the same index twice
+    if (lastRequestedIndexRef.current === currentIndex) {
+      return
+    }
+    lastRequestedIndexRef.current = currentIndex
     isLoadingMoreRef.current = true
-    fetchResults(startIndex, true)
-  }, [fetchResults, startIndex, isLoading, hasMore])
+    fetchResults(currentIndex, true)
+  }, [fetchResults, isLoading, hasMore])
 
   return { results, isLoading, error, loadMore, hasMore }
 }

--- a/src/services/google-books.test.ts
+++ b/src/services/google-books.test.ts
@@ -181,6 +181,32 @@ describe('searchBooks', () => {
     }
   })
 
+  it('adjusts totalItems when merged results are fewer than maxResults', async () => {
+    const vol1 = mockVolume()
+    let callCount = 0
+    server.use(
+      http.get(BOOKS_API, () => {
+        callCount++
+        if (callCount === 1) {
+          // intitle returns 1 result
+          return HttpResponse.json(mockSearchResponse([vol1], 500))
+        }
+        // inauthor returns same result (duplicate)
+        return HttpResponse.json(mockSearchResponse([vol1], 300))
+      }),
+    )
+    const result = await searchBooks('key', 'test', {
+      startIndex: 0,
+      maxResults: 20,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.items).toHaveLength(1)
+      // totalItems should be capped since merged results (1) < maxResults (20)
+      expect(result.data.totalItems).toBe(1)
+    }
+  })
+
   it('handles missing thumbnails', async () => {
     server.use(
       http.get(BOOKS_API, () =>

--- a/src/services/google-books.ts
+++ b/src/services/google-books.ts
@@ -156,7 +156,13 @@ export async function searchBooks(
   // Use the larger totalItems as an approximation
   const titleTotal = titleResult.ok ? titleResult.data.totalItems : 0
   const authorTotal = authorResult.ok ? authorResult.data.totalItems : 0
-  const totalItems = Math.max(titleTotal, authorTotal)
+  let totalItems = Math.max(titleTotal, authorTotal)
+
+  // If merged results are fewer than maxResults, we've reached the end;
+  // cap totalItems to prevent infinite pagination loops.
+  if (mapped.length < maxResults) {
+    totalItems = startIndex + mapped.length
+  }
 
   const response: Result<PaginatedResponse<SearchResultItem>> = {
     ok: true,

--- a/src/services/lastfm.test.ts
+++ b/src/services/lastfm.test.ts
@@ -189,6 +189,78 @@ describe('searchMusic', () => {
     }
   })
 
+  it('adjusts totalItems when thumbnail filtering removes all items', async () => {
+    server.use(
+      http.get(LASTFM_BASE, () =>
+        HttpResponse.json(
+          mockAlbumSearchResponse(
+            [
+              mockAlbum({
+                name: 'No Image 1',
+                image: [
+                  { '#text': '', size: 'small' },
+                  { '#text': '', size: 'extralarge' },
+                ],
+              }),
+              mockAlbum({
+                name: 'No Image 2',
+                image: [
+                  { '#text': '', size: 'small' },
+                  { '#text': '', size: 'extralarge' },
+                ],
+              }),
+            ],
+            '100',
+          ),
+        ),
+      ),
+    )
+    const { searchMusic } = await import('./lastfm')
+    const result = await searchMusic('api-key', 'test')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.items).toHaveLength(0)
+      // totalItems should be adjusted so hasMore = false
+      expect(result.data.totalItems).toBe(0)
+    }
+  })
+
+  it('adjusts totalItems when thumbnail filtering reduces items', async () => {
+    server.use(
+      http.get(LASTFM_BASE, () =>
+        HttpResponse.json(
+          mockAlbumSearchResponse(
+            [
+              mockAlbum({ name: 'Good Album' }),
+              mockAlbum({
+                name: 'No Image',
+                image: [
+                  { '#text': '', size: 'small' },
+                  { '#text': '', size: 'extralarge' },
+                ],
+              }),
+            ],
+            '100',
+          ),
+        ),
+      ),
+    )
+    const { searchMusic } = await import('./lastfm')
+    const result = await searchMusic('api-key', 'test', {
+      startIndex: 0,
+      maxResults: 20,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.items).toHaveLength(1)
+      // When fewer items returned than raw (due to filtering) and raw < maxResults,
+      // totalItems should be capped
+      expect(result.data.totalItems).toBeLessThanOrEqual(
+        result.data.startIndex + result.data.items.length,
+      )
+    }
+  })
+
   it('filters out albums with no images', async () => {
     server.use(
       http.get(LASTFM_BASE, () =>

--- a/src/services/lastfm.ts
+++ b/src/services/lastfm.ts
@@ -141,11 +141,25 @@ export async function searchMusic(
     .map(mapSearchAlbumToResult)
     .filter((item) => item.thumbnailUrl !== '')
 
+  // Adjust totalItems to prevent infinite pagination loops:
+  // If filtering reduced the item count and the raw results were fewer
+  // than a full page, we've reached the end of meaningful results.
+  let adjustedTotal = total
+  if (mapped.length < albums.length) {
+    if (albums.length < maxResults) {
+      // Last page: cap totalItems to actual items returned
+      adjustedTotal = startIndex + mapped.length
+    } else if (mapped.length === 0) {
+      // Full page but all filtered out: signal end to prevent loop
+      adjustedTotal = startIndex
+    }
+  }
+
   const response: Result<PaginatedResponse<SearchResultItem>> = {
     ok: true,
     data: {
       items: mapped,
-      totalItems: total,
+      totalItems: adjustedTotal,
       startIndex,
     },
   }


### PR DESCRIPTION
## 対応Issue
closes #283

## 概要
検索結果の無限スクロール（`loadMore`）が無限ループに陥り、レートリミッターを消費して429エラーが発生する問題を修正。

## 修正内容

### A. `useSearch` (フロント)
- `startIndex` を `useRef` で管理し、stale closure による同じ index の繰り返しリクエストを防止
- `lastRequestedIndexRef` で同一 index への重複リクエストをガード
- append 時に全件が重複だった場合 `hasMore = false` に設定してループを停止

### B. `lastfm.ts` (バックエンド)
- サムネイルフィルタリング後に `totalItems` を調整
  - 全件フィルタ除外時: `totalItems = startIndex` (ページネーション終了)
  - 最終ページでフィルタ減少時: `totalItems = startIndex + mapped.length`

### C. `google-books.ts` (バックエンド)
- マージ後の結果が `maxResults` 未満の場合、`totalItems` をキャップして不正確な推定値による無限ループを防止

## テスト
- 全779テスト通過
- 各修正箇所に対応するテストケースを追加:
  - `useSearch`: 全件重複時のページネーション停止テスト
  - `lastfm.ts`: フィルタリング後の totalItems 調整テスト (2件)
  - `google-books.ts`: マージ後の totalItems キャップテスト