### PR TITLE
fix: リアクションエンドポイントにIP単位のレートリミットを追加 (#286)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -72,6 +72,7 @@ app.route(
   createSharesApp(sharesDataPath, {
     adminApiKey: process.env['ADMIN_API_KEY'],
     ttlSeconds: SHARE_TTL_SECONDS,
+    reactionRateLimit: { windowMs: 60_000, max: 30 },
   }),
 )
 

--- a/src/server/routes/shares.test.ts
+++ b/src/server/routes/shares.test.ts
@@ -423,8 +423,9 @@ describe('shares route', () => {
   })
 
   describe('POST /:id/reactions', () => {
-    async function createShare() {
-      const res = await app.request('/', {
+    async function createShare(a?: ReturnType<typeof createSharesApp>) {
+      const target = a ?? app
+      const res = await target.request('/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -495,6 +496,86 @@ describe('shares route', () => {
         body: JSON.stringify({ clientId: 'client-1' }),
       })
       expect(res.status).toBe(404)
+    })
+
+    it('rate limits reactions per IP (30 req/min)', async () => {
+      const rateLimitedApp = createSharesApp(
+        path.join(tmpDir, 'shares-rl.db'),
+        { reactionRateLimit: { windowMs: 60_000, max: 30 } },
+      )
+      const id = await createShare(rateLimitedApp)
+
+      // Send 30 requests from the same IP – all should succeed
+      for (let i = 0; i < 30; i++) {
+        const res = await rateLimitedApp.request(`/${id}/reactions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-forwarded-for': '1.2.3.4',
+          },
+          body: JSON.stringify({ clientId: `spammer-${i}` }),
+        })
+        expect(res.status).toBe(200)
+      }
+
+      // 31st request should be rate limited
+      const res = await rateLimitedApp.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '1.2.3.4',
+        },
+        body: JSON.stringify({ clientId: 'spammer-31' }),
+      })
+      expect(res.status).toBe(429)
+      const json = (await res.json()) as {
+        ok: boolean
+        error: { kind: string }
+      }
+      expect(json.ok).toBe(false)
+      expect(json.error.kind).toBe('rate_limit')
+    })
+
+    it('rate limits reactions independently per IP', async () => {
+      const rateLimitedApp = createSharesApp(
+        path.join(tmpDir, 'shares-rl2.db'),
+        { reactionRateLimit: { windowMs: 60_000, max: 2 } },
+      )
+      const id = await createShare(rateLimitedApp)
+
+      // IP A: 2 requests (at limit)
+      for (let i = 0; i < 2; i++) {
+        await rateLimitedApp.request(`/${id}/reactions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-forwarded-for': '10.0.0.1',
+          },
+          body: JSON.stringify({ clientId: `a-${i}` }),
+        })
+      }
+
+      // IP B should still be allowed
+      const res = await rateLimitedApp.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '10.0.0.2',
+        },
+        body: JSON.stringify({ clientId: 'b-0' }),
+      })
+      expect(res.status).toBe(200)
+
+      // IP A should be blocked
+      const blocked = await rateLimitedApp.request(`/${id}/reactions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '10.0.0.1',
+        },
+        body: JSON.stringify({ clientId: 'a-extra' }),
+      })
+      expect(blocked.status).toBe(429)
     })
 
     it('includes reactionCount in list response', async () => {

--- a/src/server/routes/shares.ts
+++ b/src/server/routes/shares.ts
@@ -19,6 +19,10 @@ const str = (v: unknown): string => (typeof v === 'string' ? v : '')
 export type SharesAppOptions = {
   adminApiKey?: string
   ttlSeconds?: number
+  reactionRateLimit?: {
+    windowMs: number
+    max: number
+  }
 }
 
 export function createSharesApp(dbPath: string, options?: SharesAppOptions) {
@@ -30,6 +34,58 @@ export function createSharesApp(dbPath: string, options?: SharesAppOptions) {
 
   const MAX_LIMIT = 50
   const DEFAULT_LIMIT = 20
+
+  // --- IP-based rate limiter for reactions ---
+  const REACTION_RATE_WINDOW_MS = options?.reactionRateLimit?.windowMs ?? 60_000
+  const REACTION_RATE_MAX = options?.reactionRateLimit?.max ?? 30
+  const reactionRateMap = new Map<string, number[]>()
+  const REACTION_RATE_MAX_KEYS = 10_000
+  const REACTION_RATE_CLEANUP_INTERVAL_MS = 5 * 60_000
+
+  const reactionRateCleanupTimer = setInterval(() => {
+    const now = Date.now()
+    for (const [key, timestamps] of reactionRateMap) {
+      const recent = timestamps.filter((t) => now - t < REACTION_RATE_WINDOW_MS)
+      if (recent.length === 0) {
+        reactionRateMap.delete(key)
+      } else {
+        reactionRateMap.set(key, recent)
+      }
+    }
+  }, REACTION_RATE_CLEANUP_INTERVAL_MS)
+  if (reactionRateCleanupTimer.unref) {
+    reactionRateCleanupTimer.unref()
+  }
+
+  function getClientIp(c: {
+    req: { header: (name: string) => string | undefined }
+  }): string {
+    const forwarded = c.req.header('x-forwarded-for')
+    if (forwarded) {
+      return forwarded.split(',')[0].trim()
+    }
+    return c.req.header('x-real-ip') ?? 'unknown'
+  }
+
+  function isReactionRateLimited(ip: string): boolean {
+    const now = Date.now()
+    const timestamps = reactionRateMap.get(ip) ?? []
+    const recent = timestamps.filter((t) => now - t < REACTION_RATE_WINDOW_MS)
+    if (recent.length >= REACTION_RATE_MAX) {
+      reactionRateMap.set(ip, recent)
+      return true
+    }
+    if (
+      !reactionRateMap.has(ip) &&
+      reactionRateMap.size >= REACTION_RATE_MAX_KEYS
+    ) {
+      const firstKey = reactionRateMap.keys().next().value
+      if (firstKey !== undefined) reactionRateMap.delete(firstKey)
+    }
+    recent.push(now)
+    reactionRateMap.set(ip, recent)
+    return false
+  }
 
   app.get('/', (c) => {
     const limitParam = parseInt(c.req.query('limit') ?? '', 10)
@@ -100,6 +156,21 @@ export function createSharesApp(dbPath: string, options?: SharesAppOptions) {
   })
 
   app.post('/:id/reactions', async (c) => {
+    // IP-based rate limiting
+    const ip = getClientIp(c)
+    if (isReactionRateLimited(ip)) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            kind: 'rate_limit',
+            message: 'Too many reactions. Please try again later.',
+          },
+        },
+        429,
+      )
+    }
+
     const id = c.req.param('id')
     const share = store.get(id)
     if (!share) {


### PR DESCRIPTION
## 概要

Closes #286

リアクション（いいね）エンドポイント `POST /api/shares/:id/reactions` に **IP単位のレートリミッター** を追加し、`clientId` を変えたスパム攻撃を防止します。

## 修正内容

| 項目 | 設定値 |
|---|---|
| レート制限 | **30リクエスト/分/IP** |
| IPの取得 | `x-forwarded-for` → `x-real-ip` → `'unknown'` |
| ストア上限 | 10,000エントリ（超過時はFIFOで削除） |
| クリーンアップ | 5分ごとに期限切れエントリを自動削除 |

## 変更ファイル

- **`src/server/routes/shares.ts`** — IP-based rate limiter 追加
- **`src/server/index.ts`** — `reactionRateLimit` オプション設定（30 req/min）
- **`src/server/routes/shares.test.ts`** — テスト2件追加

## テスト

- 全785テスト ✅ パス
- lint / format ✅ クリーン

## 追加テスト

- 同一IPから30リクエスト超過で429が返ること
- 異なるIPは独立してカウントされること