### PR TITLE
fix: ThemeInputのmaxLengthを50文字に制限し、超過入力を防止

### DIFF
--- a/src/components/ThemeInput.test.tsx
+++ b/src/components/ThemeInput.test.tsx
@@ -28,6 +28,24 @@ describe('ThemeInput', () => {
     render(<ThemeInput value={longText} onChange={vi.fn()} />)
     expect(screen.getByText(/50文字以内/)).toBeInTheDocument()
   })
+
+  it('sets maxLength to MAX_THEME_LENGTH to prevent over-limit input', () => {
+    render(<ThemeInput value="" onChange={vi.fn()} />)
+    const input = screen.getByRole('textbox', { name: 'お題' })
+    expect(input).toHaveAttribute('maxLength', '50')
+  })
+
+  it('truncates onChange value to MAX_THEME_LENGTH', async () => {
+    const onChange = vi.fn()
+    render(<ThemeInput value="" onChange={onChange} />)
+    const input = screen.getByRole('textbox', { name: 'お題' })
+    const longText = 'あ'.repeat(60)
+    await userEvent.setup().type(input, longText)
+    // All calls should have values of length <= 50
+    onChange.mock.calls.forEach(([val]: [string]) => {
+      expect(val.length).toBeLessThanOrEqual(50)
+    })
+  })
 })
 
 it('renders suggestion chips', () => {

--- a/src/components/ThemeInput.test.tsx
+++ b/src/components/ThemeInput.test.tsx
@@ -42,9 +42,9 @@ describe('ThemeInput', () => {
     const longText = 'あ'.repeat(60)
     await userEvent.setup().type(input, longText)
     // All calls should have values of length <= 50
-    onChange.mock.calls.forEach(([val]: [string]) => {
-      expect(val.length).toBeLessThanOrEqual(50)
-    })
+    for (const call of onChange.mock.calls) {
+      expect((call[0] as string).length).toBeLessThanOrEqual(50)
+    }
   })
 })
 

--- a/src/components/ThemeInput.tsx
+++ b/src/components/ThemeInput.tsx
@@ -18,14 +18,14 @@ function ThemeInput({ value, onChange }: ThemeInputProps) {
     <div className="flex flex-wrap items-center gap-2">
       <TextField
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => onChange(e.target.value.slice(0, MAX_THEME_LENGTH))}
         placeholder="お題を入力（任意）"
         error={isOverLimit}
         variant="outlined"
         size="small"
         slotProps={{
           htmlInput: {
-            maxLength: MAX_THEME_LENGTH + 10,
+            maxLength: MAX_THEME_LENGTH,
             'aria-label': 'お題',
           },
           input: {


### PR DESCRIPTION
## 修正内容

Closes #287

### 問題
- ThemeInputコンポーネントの`maxLength`が`MAX_THEME_LENGTH + 10`（60文字）に設定されており、50文字を超える入力が可能だった
- APIは50文字制限で正しく弾くが、フロント側で入力を防止できていなかった

### 修正
- `htmlInput.maxLength`を`MAX_THEME_LENGTH`（50）に変更
- `onChange`ハンドラで`slice(0, MAX_THEME_LENGTH)`による切り詰めを追加（二重防御）

### テスト
- `maxLength`属性が50であることを検証するテストを追加
- `onChange`で渡される値が50文字以内であることを検証するテストを追加
- 全787テスト通過確認済み