### PR TITLE
fix: 検索エラー時にサーバーのバリデーションメッセージを表示する

### DIFF
--- a/src/hooks/useSearch.test.ts
+++ b/src/hooks/useSearch.test.ts
@@ -239,6 +239,41 @@ describe('useSearch', () => {
     expect(callCount).toBeLessThanOrEqual(3)
   })
 
+  it('displays server error message from response body on 400', async () => {
+    server.use(
+      http.get('/api/books/search', () => {
+        return HttpResponse.json(
+          {
+            ok: false,
+            error: {
+              kind: 'unknown',
+              message: 'Query exceeds maximum length of 200',
+            },
+          },
+          { status: 400 },
+        )
+      }),
+    )
+    const { result } = renderHook(() => useSearch('book', 'test'))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.error).toBe('Query exceeds maximum length of 200')
+  })
+
+  it('falls back to HTTP status when error body is not parseable', async () => {
+    server.use(
+      http.get('/api/books/search', () => {
+        return new HttpResponse('Bad Request', { status: 400 })
+      }),
+    )
+    const { result } = renderHook(() => useSearch('book', 'test'))
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.error).toBe('HTTP 400')
+  })
+
   it('uses API_ENDPOINTS for movie category', async () => {
     let requestedUrl = ''
     server.use(

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -67,7 +67,16 @@ export function useSearch(
           if (response.status === 429) {
             throw new Error(MESSAGES.RATE_LIMITED)
           }
-          throw new Error(`HTTP ${response.status}`)
+          let serverMessage: string | undefined
+          try {
+            const errorJson = (await response.json()) as {
+              error?: { message?: string }
+            }
+            serverMessage = errorJson?.error?.message
+          } catch {
+            // Response body is not valid JSON – fall through
+          }
+          throw new Error(serverMessage || `HTTP ${response.status}`)
         }
 
         const json = (await response.json()) as {


### PR DESCRIPTION
## 修正内容

Closes #288

### 問題
検索でバリデーションエラー（HTTP 400）が発生した場合、サーバーは詳細なエラーメッセージを返しているが、フロント側は `HTTP 400` としか表示しなかった。

### 修正
`useSearch.ts` でエラーレスポンスのボディを読み、`error.message` があればそれをユーザーに表示するように変更。JSONパース失敗時は従来通り `HTTP {status}` にフォールバック。

### テスト
- サーバーがエラーメッセージ付き400を返した場合にそのメッセージを表示するテスト追加
- レスポンスボディがJSON以外の場合にHTTPステータスにフォールバックするテスト追加
- 全789テスト通過確認済み